### PR TITLE
Pythonのライブラリ名を変数にしました．

### DIFF
--- a/src/OpenRTMPlugin/pybind11/CMakeLists.txt
+++ b/src/OpenRTMPlugin/pybind11/CMakeLists.txt
@@ -5,4 +5,4 @@ add_cnoid_python_module(${target}
   PyItems.cpp
 )
 
-target_link_libraries(${target} CnoidOpenRTMPlugin CnoidPyBase C:/Python37/Libs/python37.lib)
+target_link_libraries(${target} CnoidOpenRTMPlugin CnoidPyBase ${CHOREONOID_PYTHON_LIBRARIES})


### PR DESCRIPTION
Choreonoid本体で以下のコミットが反映されていることが前提です．
https://github.com/s-nakaoka/choreonoid/commit/a476add49d1a690c7eaf7fd6e0674a9e8a7f2f69