### PR TITLE
[BodyRTCItem] Make CORBA initialization error more explicit

### DIFF
--- a/src/OpenRTMPlugin/RTCItem.cpp
+++ b/src/OpenRTMPlugin/RTCItem.cpp
@@ -380,7 +380,7 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
                 string initFunc(componentName + "Init");
                 setupModules(actualFilename, initFunc, componentName, prop);
             } else {
-                mv->putln(format(_("A file of RTC \"{}\" does not exist."), componentName));
+                mv->putln(MessageView::ERROR,format(_("File \"{}\" of RTC \"{}\" does not exist."), dllPath.string(), componentName));
             }
         }
     }
@@ -390,7 +390,7 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
     if (created) {
         mv->putln(format(_("RTC \"{0}\" has been created from \"{1}\"."), componentName, actualFilename));
     } else {
-        mv->putln(format(_("RTC \"{}\" cannot be created."), componentName));
+        mv->putln(MessageView::ERROR, format(_("RTC \"{}\" cannot be created."), componentName));
     }
 
     return created;

--- a/src/OpenRTMPlugin/deprecated/BodyRTCItem.cpp
+++ b/src/OpenRTMPlugin/deprecated/BodyRTCItem.cpp
@@ -854,14 +854,22 @@ bool BodyRTCItemImpl::restore(const Archive& archive)
 void BodyRTCItemImpl::detectRtcs()
 {
     RTC::Manager& rtcManager = RTC::Manager::instance();
-    
+
     string nameServer = rtcManager.getConfig()["corba.nameservers"];
     int comPos = nameServer.find(",");
     if (comPos < 0){
         comPos = nameServer.length();
     }
     nameServer = nameServer.substr(0, comPos);
-    naming = new RTC::CorbaNaming(rtcManager.getORB(), nameServer.c_str());
+    try
+    {
+      naming = new RTC::CorbaNaming(rtcManager.getORB(), nameServer.c_str());
+    }
+    catch(std::bad_alloc & e)
+    {
+      mv->putln(format(_("[BodyRTCItem] Failed to create CorbaNaming with nameserver: \"{}\" (configured from RTC Manager \"corba.nameservers\"). Exception was {}"), nameServer, e.what()));
+      return;
+    }
 
     for(TimeRateMap::iterator it = bridgeConf->timeRateMap.begin(); it != bridgeConf->timeRateMap.end(); ++it){
         RTC::RTObject_var rtcRef;


### PR DESCRIPTION
If the nameserver defined in the RTC manager configuration property `corba.nameservers` is invalid, openrtm-aist throws an exception (without error message) since CORBA could not be initialized properly.  However, the BodyRTCItem does not catch it, which causes choreonoid to terminate without any explanation regarding the source of the problem.

This PR simply catches the exception and displays an informative error message. 

Note: when creating the `BodyRTCItem` from a `.cnoid` configuration file, loading will continue even though the item could not be created properly. In my opinion choreonoid should stop loading subsequent items as soon as a failure is detected. This is way out-of-scope for this PR.