### PR TITLE
Choreonoid開発版(2022/01/14時点)への対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,12 @@ else()
     add_compile_options(-std=c++14)
   endif()
 
+  if(MSVC)
+    if(${MSVC_VERSION} GREATER_EQUAL 1910)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+    endif()
+  endif()
+
   option(INSTALL_SDK "Installing SDK files" ON)
   set(CHOREONOID_INSTALL_SDK ${INSTALL_SDK})
 
@@ -101,7 +107,7 @@ else()
   if(MSVC)
     unset(camera_library)
     foreach(dir ${OPENRTM_LIBRARY_DIRS})
-      file(GLOB libs "${dir}/rtmCamera*.lib")
+      file(GLOB libs "${dir}/rtmCamera*vc*.lib")
       foreach(lib ${libs})
         if(lib MATCHES "(rtmCamera.*d)\\.lib$")
           list(APPEND camera_library debug;${CMAKE_MATCH_1})
@@ -115,6 +121,34 @@ else()
     set(OPENRTM_CAMERA_LIBRARY rtmCamera)
   endif()
 endif()
+
+
+
+
+if(IS_MASTER_PROJECT)
+  if(MSVC)
+    set(USE_BUNDLED_LIBJPEG_DEFAULT ON)
+  else()
+    set(USE_BUNDLED_LIBJPEG_DEFAULT OFF)
+  endif()
+  option(USE_BUNDLED_LIBJPEG "Use the JPEG library bunded with Choreonoid" ${USE_BUNDLED_LIBJPEG_DEFAULT})
+  if(NOT USE_BUNDLED_LIBJPEG)
+    find_package(JPEG)
+  endif()
+  if(NOT JPEG_FOUND)
+    set(JPEG_LIBRARY jpeg)
+  endif()
+endif()
+set(OPENRTM_CAMERA_LIBRARY ${OPENRTM_CAMERA_LIBRARY} ${JPEG_LIBRARY})
+
+
+if(MSVC)
+  file(GLOB rtcdlls "${OPENRTM_BIN_PATH}/RTC*vc*.dll")
+  file(GLOB rtmcameradlls "${OPENRTM_BIN_PATH}/rtmCamera*vc*.dll")
+  file(GLOB rtmmanipulatordlls "${OPENRTM_BIN_PATH}/rtmManipulator*vc*.dll")
+  install(PROGRAMS ${rtcdlls} ${rtmcameradlls} ${rtmmanipulatordlls} DESTINATION ${CHOREONOID_BIN_SUBDIR} COMPONENT openrtmlib)
+endif()
+
 
 if(NOT IS_MASTER_PROJECT)
   set(OPENRTM_DEFINITIONS ${OPENRTM_DEFINITIONS} PARENT_SCOPE)

--- a/sample/PA10PickupControllerRTC.cpp
+++ b/sample/PA10PickupControllerRTC.cpp
@@ -9,6 +9,7 @@
 #include <cnoid/Link>
 #include <cnoid/EigenUtil>
 #include <cnoid/FileUtil>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 using namespace cnoid;
@@ -70,7 +71,7 @@ RTC::ReturnCode_t PA10PickupControllerRTC::onInitialize()
     addOutPort("u_out", m_torqueOut);
 
     string modelfile = getNativePathString(
-        boost::filesystem::path(shareDirectory()) / "model/PA10/PA10.body");
+        cnoid::stdx::filesystem::path(shareDirectory()) / "model/PA10/PA10.body");
             
     BodyLoader loader;
     loader.setMessageSink(cout);

--- a/sample/SR1LiftupControllerRTC.cpp
+++ b/sample/SR1LiftupControllerRTC.cpp
@@ -9,6 +9,7 @@
 #include <cnoid/Link>
 #include <cnoid/EigenUtil>
 #include <cnoid/FileUtil>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 using namespace cnoid;
@@ -79,7 +80,7 @@ RTC::ReturnCode_t SR1LiftupControllerRTC::onInitialize()
     addOutPort("u_out", m_torqueOut);
 
     string modelfile = getNativePathString(
-        boost::filesystem::path(shareDirectory()) / "model/SR1/SR1.body");
+       cnoid::stdx::filesystem::path(shareDirectory()) / "model/SR1/SR1.body");
             
     BodyLoader loader;
     loader.setMessageSink(cout);

--- a/sample/SR1WalkControllerRTC.cpp
+++ b/sample/SR1WalkControllerRTC.cpp
@@ -7,6 +7,7 @@
 #include <cnoid/BodyMotion>
 #include <cnoid/ExecutablePath>
 #include <cnoid/FileUtil>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 using namespace cnoid;
@@ -74,7 +75,7 @@ RTC::ReturnCode_t SR1WalkControllerRTC::onActivated(RTC::UniqueId ec_id)
 {
     if(!qseq){
         string filename = getNativePathString(
-            boost::filesystem::path(shareDirectory())
+            cnoid::stdx::filesystem::path(shareDirectory())
             / "motion" / "SR1" / "SR1WalkPattern1.seq");
 
         BodyMotion motion;

--- a/src/OpenRTMPlugin/BodyIoRTCItem.cpp
+++ b/src/OpenRTMPlugin/BodyIoRTCItem.cpp
@@ -40,6 +40,7 @@ public:
     virtual double currentTime() const override;
     virtual bool isNoDelayMode() const override;
     virtual bool setNoDelayMode(bool on) override;
+    virtual std::string controllerName(void) const override;
 };
 
 }
@@ -182,9 +183,14 @@ bool BodyIoRTCItemImpl::isNoDelayMode() const
 
 bool BodyIoRTCItemImpl::setNoDelayMode(bool on)
 {
-    return self->setNoDelayMode(on);
+    self->setNoDelayMode(on);
+    return on;
 }
-        
+
+std::string BodyIoRTCItemImpl::controllerName(void) const
+{
+    return self->name();
+}
 
 bool BodyIoRTCItem::createRTC()
 {

--- a/src/OpenRTMPlugin/ControllerRTCItem.cpp
+++ b/src/OpenRTMPlugin/ControllerRTCItem.cpp
@@ -15,12 +15,12 @@
 #include <cnoid/FileUtil>
 #include <cnoid/CorbaUtil>
 #include <fmt/format.h>
+#include <boost/filesystem.hpp>
 #include "gettext.h"
 
 using namespace std;
 using namespace cnoid;
 using fmt::format;
-namespace filesystem = boost::filesystem;
 
 namespace {
 
@@ -64,7 +64,7 @@ public:
     };
     Selection baseDirectoryType;
 
-    filesystem::path rtcDirectory;
+    cnoid::stdx::filesystem::path rtcDirectory;
 
     Selection execContextType;
     bool useOnlySimulationExecutionContext = false;
@@ -121,7 +121,7 @@ ControllerRTCItemImpl::ControllerRTCItemImpl(ControllerRTCItem* self)
     baseDirectoryType.setSymbol(PROJECT_DIRECTORY, N_("Project directory"));
     baseDirectoryType.select(RTC_DIRECTORY);
 
-    rtcDirectory = filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
+    rtcDirectory = cnoid::stdx::filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
 
     execContextType.setSymbol(SIMULATION_EXECUTION_CONTEXT,  N_("SimulationExecutionContext"));
     execContextType.setSymbol(SIMULATION_PERIODIC_EXECUTION_CONTEXT,  N_("SimulationPeriodicExecutionContext"));
@@ -192,14 +192,14 @@ void ControllerRTCItem::setRTCModule(const std::string& name)
 void ControllerRTCItemImpl::setRTCModule(const std::string& name)
 {
     if(name != moduleNameProperty){
-        filesystem::path modulePath(name);
+        cnoid::stdx::filesystem::path modulePath(name);
         if(modulePath.is_absolute()){
             baseDirectoryType.select(NO_BASE_DIRECTORY);
             if(modulePath.parent_path() == rtcDirectory){
                 baseDirectoryType.select(RTC_DIRECTORY);
                 modulePath = modulePath.filename();
             } else {
-                filesystem::path projectDir(ProjectManager::instance()->currentProjectDirectory());
+                cnoid::stdx::filesystem::path projectDir(ProjectManager::instance()->currentProjectDirectory());
                 if(!projectDir.empty() && (modulePath.parent_path() == projectDir)){
                     baseDirectoryType.select(PROJECT_DIRECTORY);
                     modulePath = modulePath.filename();
@@ -298,7 +298,7 @@ std::string ControllerRTCItemImpl::getModuleFilename()
         return string();
     }
     
-    filesystem::path path(moduleNameProperty);
+    cnoid::stdx::filesystem::path path(moduleNameProperty);
 
     moduleName = path.stem().string();
     
@@ -308,7 +308,7 @@ std::string ControllerRTCItemImpl::getModuleFilename()
         } else if(baseDirectoryType.is(PROJECT_DIRECTORY)){
             string projectDir = ProjectManager::instance()->currentProjectDirectory();
             if(!projectDir.empty()){
-                path = filesystem::path(projectDir) / path;
+                path = cnoid::stdx::filesystem::path(projectDir) / path;
             } else {
                 mv->putln(
                     format(_("The rtc of {} cannot be generated because the project directory "
@@ -326,7 +326,7 @@ std::string ControllerRTCItemImpl::getModuleFilename()
         path += DLL_EXTENSION;
     }
         
-    if(filesystem::exists(path)){
+    if(cnoid::stdx::filesystem::exists(path)){
         return path.string();
     } else {
         mv->putln(
@@ -685,7 +685,7 @@ bool ControllerRTCItemImpl::restore(const Archive& archive)
     DDEBUG("ControllerRTCItemImpl::restore");
     string value;
     if(archive.read("module", value) || archive.read("moduleName", value)){
-        filesystem::path path(archive.expandPathVariables(value));
+        cnoid::stdx::filesystem::path path(archive.expandPathVariables(value));
         moduleNameProperty = path.make_preferred().string();
     }
     if(archive.read("baseDirectory", value) || archive.read("pathBaseType", value)){

--- a/src/OpenRTMPlugin/ControllerRTCItem.cpp
+++ b/src/OpenRTMPlugin/ControllerRTCItem.cpp
@@ -15,7 +15,6 @@
 #include <cnoid/FileUtil>
 #include <cnoid/CorbaUtil>
 #include <fmt/format.h>
-#include <boost/filesystem.hpp>
 #include "gettext.h"
 
 using namespace std;

--- a/src/OpenRTMPlugin/OpenRTMPlugin.cpp
+++ b/src/OpenRTMPlugin/OpenRTMPlugin.cpp
@@ -43,7 +43,6 @@
 #include <fmt/format.h>
 #include <rtm/ComponentActionListener.h>
 #include <set>
-#include <boost/filesystem.hpp>
 
 #include "LoggerUtil.h"
 

--- a/src/OpenRTMPlugin/OpenRTMPlugin.cpp
+++ b/src/OpenRTMPlugin/OpenRTMPlugin.cpp
@@ -43,15 +43,16 @@
 #include <fmt/format.h>
 #include <rtm/ComponentActionListener.h>
 #include <set>
+#include <boost/filesystem.hpp>
 
 #include "LoggerUtil.h"
 
 #include "gettext.h"
+#include "exportdecl.h"
 
 using namespace std;
 using namespace cnoid;
 using fmt::format;
-namespace filesystem = boost::filesystem;
 
 namespace {
 
@@ -110,7 +111,7 @@ public:
         if (RTC::ExecutionContextFactory::instance().addFactory(
             name,
             ::coil::Creator<::RTC::ExecutionContextBase, ExecutionContextType>,
-            ::coil::Destructor<::RTC::ExecutionContextBase, ExecutionContextType>) == 0) {
+            ::coil::Destructor<::RTC::ExecutionContextBase, ExecutionContextType>) == coil::FactoryReturn::OK) {
 #endif
             mv->putln(format(_("{} has been registered."), name));
         } else {
@@ -146,7 +147,7 @@ public:
         }
         DDEBUG_V("configFile : %s", configFile.c_str());
 
-        bool isConfFileSpecified = filesystem::exists(configFile);
+        bool isConfFileSpecified = cnoid::stdx::filesystem::exists(configFile);
 
         const char* argv[] = {
             "choreonoid",
@@ -368,7 +369,8 @@ public:
 
         cnoid::deleteUnmanagedRTCs();
 
-        manager->shutdown();
+        //manager->shutdown();
+        manager->terminate();
         manager->unloadAll();
 
         return true;

--- a/src/OpenRTMPlugin/RTCItem.cpp
+++ b/src/OpenRTMPlugin/RTCItem.cpp
@@ -23,7 +23,6 @@
 using namespace std;
 using namespace cnoid;
 using fmt::format;
-namespace filesystem = cnoid::stdx::filesystem;
 
 namespace {
 const bool TRACE_FUNCTIONS = false;
@@ -36,13 +35,13 @@ class RTComponentImpl
 public:
     RTC::RTObject_var rtcRef;
     RTC::RtcBase* rtc_;
-    filesystem::path modulePath;
+    cnoid::stdx::filesystem::path modulePath;
     Process rtcProcess;
     std::string componentName;
     MessageView* mv;
 
-    RTComponentImpl(const filesystem::path& modulePath, PropertyMap& prop);
-    void init(const filesystem::path& modulePath, PropertyMap& properties);
+    RTComponentImpl(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& prop);
+    void init(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& properties);
     bool createRTC(PropertyMap& properties);
     bool isValid() const;
     void setupModules(string& fileName, string& initFuncName, string& componentName, PropertyMap& properties);
@@ -98,7 +97,7 @@ RTCItem::RTCItem()
     baseDirectoryType.select(RTC_DIRECTORY);
     oldBaseDirectoryType = baseDirectoryType.which();
 
-    rtcDirectory = filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
+    rtcDirectory = cnoid::stdx::filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
 
     isActivationEnabled_ = false;
 }
@@ -269,7 +268,7 @@ bool RTCItem::restore(const Archive& archive)
     }
     string value;
     if (archive.read("module", value) || archive.read("moduleName", value)) {
-        filesystem::path path(archive.expandPathVariables(value));
+        cnoid::stdx::filesystem::path path(archive.expandPathVariables(value));
         moduleName = path.make_preferred().string();
     }
     if (archive.read("baseDirectory", value) || archive.read("RelativePathBase", value)) {
@@ -305,7 +304,7 @@ bool RTCItem::convertAbsolutePath()
                 mv->putln(_("Please save the project."));
                 return false;
             } else {
-                modulePath = filesystem::path(projectDir) / modulePath;
+                modulePath = cnoid::stdx::filesystem::path(projectDir) / modulePath;
             }
         }
     }
@@ -313,14 +312,14 @@ bool RTCItem::convertAbsolutePath()
 }
 
 
-RTComponent::RTComponent(const filesystem::path& modulePath, PropertyMap& prop)
+RTComponent::RTComponent(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& prop)
 {
     DDEBUG("RTComponent::RTComponent");
     impl = new RTComponentImpl(modulePath, prop);
 }
 
 
-RTComponentImpl::RTComponentImpl(const filesystem::path& modulePath, PropertyMap& prop)
+RTComponentImpl::RTComponentImpl(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& prop)
 {
     rtc_ = nullptr;
     rtcRef = RTC::RTObject::_nil();
@@ -337,7 +336,7 @@ RTComponent::~RTComponent()
 }
 
 
-void RTComponentImpl::init(const filesystem::path& modulePath_, PropertyMap& prop)
+void RTComponentImpl::init(const cnoid::stdx::filesystem::path& modulePath_, PropertyMap& prop)
 {
     DDEBUG("RTComponentImpl::init");
     mv = MessageView::instance();
@@ -350,7 +349,7 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
 {
     DDEBUG("RTComponentImpl::createRTC");
 
-    string moduleNameLeaf = modulePath.leaf().string();
+    string moduleNameLeaf = modulePath.filename().string();
     size_t i = moduleNameLeaf.rfind('.');
     if (i != string::npos) {
         componentName = moduleNameLeaf.substr(0, i);
@@ -360,7 +359,7 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
 
     string actualFilename;
 
-    if (filesystem::exists(modulePath)) {
+    if (cnoid::stdx::filesystem::exists(modulePath)) {
         actualFilename = getNativePathString(modulePath);
         if (modulePath.extension() == DLL_SUFFIX) {
             string initFunc(componentName + "Init");
@@ -369,13 +368,13 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
             createProcess(actualFilename, prop);
         }
     } else {
-        filesystem::path exePath(modulePath.string() + EXEC_SUFFIX);
-        if (filesystem::exists(exePath)) {
+        cnoid::stdx::filesystem::path exePath(modulePath.string() + EXEC_SUFFIX);
+        if (cnoid::stdx::filesystem::exists(exePath)) {
             actualFilename = getNativePathString(exePath);
             createProcess(actualFilename, prop);
         } else {
-            filesystem::path dllPath(modulePath.string() + DLL_SUFFIX);
-            if (filesystem::exists(dllPath)) {
+            cnoid::stdx::filesystem::path dllPath(modulePath.string() + DLL_SUFFIX);
+            if (cnoid::stdx::filesystem::exists(dllPath)) {
                 actualFilename = getNativePathString(dllPath);
                 string initFunc(componentName + "Init");
                 setupModules(actualFilename, initFunc, componentName, prop);

--- a/src/OpenRTMPlugin/RTSDiagramView.cpp
+++ b/src/OpenRTMPlugin/RTSDiagramView.cpp
@@ -18,6 +18,7 @@
 #include <cnoid/RootItem>
 #include <cnoid/SimulatorItem>
 #include <cnoid/AppConfig>
+#include <cnoid/Archive>
 #include <QGraphicsLineItem>
 #include <QGraphicsOpacityEffect>
 #include <QGraphicsScene>

--- a/src/OpenRTMPlugin/RTSNameServerView.cpp
+++ b/src/OpenRTMPlugin/RTSNameServerView.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include "RTSNameServerView.h"
 #include "RTSCommonUtil.h"
 #include "OpenRTMUtil.h"
@@ -11,6 +11,8 @@
 #include <cnoid/CheckBox>
 #include <cnoid/ComboBox>
 #include <cnoid/MessageView>
+#include <cnoid/Archive>
+#include <cnoid/EigenArchive>
 #include <rtm/CORBA_IORUtil.h>
 #include <QLabel>
 #include <QGridLayout>
@@ -116,7 +118,8 @@ private:
         vector<NamingContextHelper::ObjectPath> pathList);
     void onSelectionChanged();
 
-    void showServerInfo();    void connectNameServer();
+    void showServerInfo();
+    void connectNameServer();
     void cleatZombee();
     void checkZombee(RTSVItem* parent);
 };
@@ -237,7 +240,8 @@ RTSNameServerViewImpl::RTSNameServerViewImpl(RTSNameServerView* self)
     vbox->addWidget(&treeWidget, 1);
     self->setLayout(vbox);
     //
-    showServerInfo();}
+    showServerInfo();
+}
 
 
 RTSNameServerView::~RTSNameServerView()

--- a/src/OpenRTMPlugin/deprecated/VirtualRobotPortHandler.cpp
+++ b/src/OpenRTMPlugin/deprecated/VirtualRobotPortHandler.cpp
@@ -248,12 +248,12 @@ void LinkDataOutPortHandler::inputDataFromSimulator(BodyRTCItem* bodyRTC)
             const size_t n = constraintForces.size();
             value.data.length(6*n);
             for(size_t i=0, j=0; i<n; i++){
-                value.data[j++] = constraintForces[i].point(0);
-                value.data[j++] = constraintForces[i].point(1);
-                value.data[j++] = constraintForces[i].point(2);
-                value.data[j++] = constraintForces[i].force(0);
-                value.data[j++] = constraintForces[i].force(1);
-                value.data[j++] = constraintForces[i].force(2);
+                value.data[j++] = constraintForces[i].position()[0];
+                value.data[j++] = constraintForces[i].position()[1];
+                value.data[j++] = constraintForces[i].position()[2];
+                value.data[j++] = constraintForces[i].force()[0];
+                value.data[j++] = constraintForces[i].force()[1];
+                value.data[j++] = constraintForces[i].force()[2];
             }
         }
     }


### PR DESCRIPTION
#7 

Choreonoid開発版(2022/01/14時点)でビルドできるように修正した。
以下の点には注意が必要。

- 以前のChoreonoidのバージョンではビルド不可
Choreonoidの関数の仕様が以前対応した時とは変わっている部分もあり、どのバージョンから変わったのか把握できていないため、過去のバージョンへの対応はやめています

- C++17に設定する場合はOpenRTM-aist 2.0以上が必要
OpenRTM-aist 1.2をC++17環境で使用するとヘッダーファイルでエラーが出るため、OpenRTM-aist 2.0以上が必要。ただ、現段階でOpenRTM-aist 2.0がリリースされていないため、OpenRTM-aist開発版をビルドする必要がある。
C++11、C++14環境は未検証のため今後確認する。
