### PR TITLE
OpenRTMPythonPluginへの対応

### DIFF
--- a/src/OpenRTMPlugin/CMakeLists.txt
+++ b/src/OpenRTMPlugin/CMakeLists.txt
@@ -33,6 +33,13 @@ set(public_headers
   RTCItem.h
   BodyIoRTCItem.h
   ControllerRTCItem.h
+  OpenRTMPlugin.h
+  ProfileHandler.h
+  RTSystem.h
+  RTSystemItem.h
+  RTSCommonUtil.h
+  RTCWrapper.h
+  RTSDiagramView.h
   deprecated/BodyRTCItem.h
   )
 
@@ -112,3 +119,6 @@ endif()
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${CHOREONOID_PLUGIN_SUBDIR}/rtc)
 install(DIRECTORY ${PROJECT_BINARY_DIR}/${CHOREONOID_PLUGIN_SUBDIR}/rtc
   DESTINATION ${CHOREONOID_PLUGIN_SUBDIR}/rtc FILES_MATCHING PATTERN "*" EXCLUDE)
+
+
+add_subdirectory(pugixml)

--- a/src/OpenRTMPlugin/OpenRTMPlugin.h
+++ b/src/OpenRTMPlugin/OpenRTMPlugin.h
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+/*!
+ * @file OpenRTMPlugin.h
+ * @brief OpenRTMPlugin include hearder files.
+ * @date $Date$
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2022
+ *     Nobuhiko Miyamoto
+ *     Software Platform Research Team,
+ *     Industrial Cyber-Physical Systems Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *     All rights reserved.
+ *
+ * $Id$
+ *
+ */
+
+#include "OpenRTMUtil.h"
+#include "RTCItem.h"
+#include "BodyIoRTCItem.h"
+#include "ControllerRTCItem.h"
+#include "ProfileHandler.h"
+#include "RTSystem.h"
+#include "RTSystemItem.h"
+#include "RTSCommonUtil.h"
+#include "RTCWrapper.h"
+#include "RTSDiagramView.h"

--- a/src/OpenRTMPlugin/RTSDiagramView.cpp
+++ b/src/OpenRTMPlugin/RTSDiagramView.cpp
@@ -300,6 +300,7 @@ public:
     void mouseMoveEvent(QMouseEvent* event);
     void mousePressEvent(QMouseEvent* event);
     void mouseReleaseEvent(QMouseEvent* event);
+    void mouseDoubleClickEvent(QMouseEvent* event);
     void wheelEvent(QWheelEvent* event);
     void keyPressEvent(QKeyEvent* event);
     void onnsViewItemSelectionChanged(const list<NamingContextHelper::ObjectInfo>& items);
@@ -316,6 +317,7 @@ public:
     void onRTSystemItemDetachedFromRoot();
     void setCurrentRTSItem(RTSystemItem* item);
     void updateView();
+    Signal<void(RTSComp*)> sigDoubleClickEvent;
     void checkStatus();
     void updateSetting();
     void updateRestoredView();
@@ -1037,6 +1039,27 @@ void RTSDiagramViewImpl::mouseMoveEvent(QMouseEvent* event)
 }
 
 
+void RTSDiagramViewImpl::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton) {
+
+
+        if (!selectionRTCs.empty()) {
+
+            sigDoubleClickEvent(selectionRTCs.front()->rtsComp);
+        }
+
+    }
+
+    QGraphicsView::mouseDoubleClickEvent(event);
+}
+
+SignalProxy<void(RTSComp*)> RTSDiagramView::sigDoubleClickEvent()
+{
+    return impl->sigDoubleClickEvent;
+}
+
+
 void RTSDiagramViewImpl::mouseReleaseEvent(QMouseEvent *event)
 {
     QPointF pos = mapToScene(event->pos());
@@ -1507,6 +1530,11 @@ void RTSDiagramViewImpl::checkStatus()
         it->second->stateCheck();
     }
 }
+
+void RTSDiagramViewImpl::updateSetting()
+{
+}
+
 
 void RTSDiagramViewImpl::updateView()
 {

--- a/src/OpenRTMPlugin/RTSDiagramView.h
+++ b/src/OpenRTMPlugin/RTSDiagramView.h
@@ -8,13 +8,16 @@
 
 #include <cnoid/View>
 #include <cnoid/Dialog>
+#include <cnoid/CorbaUtil>
+#include "exportdecl.h"
 
 using namespace cnoid;
 
 namespace cnoid {
 class RTSDiagramViewImpl;
+class RTSComp;
 
-class RTSDiagramView : public View
+class CNOID_EXPORT RTSDiagramView : public View
 {
     Q_OBJECT
 
@@ -24,6 +27,8 @@ public:
 
     RTSDiagramView();
     virtual ~RTSDiagramView();
+
+    SignalProxy<void(RTSComp*)> sigDoubleClickEvent();
 
 public Q_SLOTS:
     void onRTSCompSelectionChange();

--- a/src/OpenRTMPlugin/deprecated/BodyRTCItem.cpp
+++ b/src/OpenRTMPlugin/deprecated/BodyRTCItem.cpp
@@ -32,7 +32,6 @@ using namespace std;
 using namespace cnoid;
 using namespace RTC;
 using fmt::format;
-namespace filesystem = cnoid::stdx::filesystem;
 
 namespace {
 
@@ -96,7 +95,7 @@ public:
     std::string confFileName;
     std::string instanceName;
     Selection baseDirectoryType;
-    filesystem::path rtcDirectory;
+    cnoid::stdx::filesystem::path rtcDirectory;
     MessageView* mv;
 
 #ifdef ENABLE_SIMULATION_PROFILING
@@ -176,7 +175,7 @@ BodyRTCItemImpl::BodyRTCItemImpl(BodyRTCItem* self)
     baseDirectoryType.setSymbol(BodyRTCItem::RTC_DIRECTORY, N_("RTC directory"));
     baseDirectoryType.setSymbol(BodyRTCItem::PROJECT_DIRECTORY, N_("Project directory"));
     baseDirectoryType.select(BodyRTCItem::RTC_DIRECTORY);
-    rtcDirectory = filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
+    rtcDirectory = cnoid::stdx::filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
 
     executionCycleProperty = 0.0;
 }
@@ -220,12 +219,12 @@ void BodyRTCItemImpl::createRTC(BodyPtr body)
 
     bridgeConf = new BridgeConf();
 
-    filesystem::path projectDir(ProjectManager::instance()->currentProjectDirectory());
+    cnoid::stdx::filesystem::path projectDir(ProjectManager::instance()->currentProjectDirectory());
 
     if(configMode.is(BodyRTCItem::CONF_ALL_MODE)){
         setdefaultPort(body);
     } else if(configMode.is(BodyRTCItem::CONF_FILE_MODE)){
-        filesystem::path confPath;
+        cnoid::stdx::filesystem::path confPath;
         if(!confFileName.empty()){
             confPath = confFileName;
         } else if(!moduleName.empty()){
@@ -279,7 +278,7 @@ void BodyRTCItemImpl::createRTC(BodyPtr body)
             prop["exec_cxt.periodic.type"] = "ChoreonoidExecutionContext";
             prop["exec_cxt.periodic.rate"] = "1000000";
 
-            filesystem::path modulePath(moduleName);
+            cnoid::stdx::filesystem::path modulePath(moduleName);
             if(!modulePath.is_absolute()){
                 if(baseDirectoryType.is(BodyRTCItem::RTC_DIRECTORY)){
                     modulePath = rtcDirectory / modulePath;
@@ -628,14 +627,14 @@ void BodyRTCItemImpl::setControllerModule(const std::string& name)
 {
     if(name != moduleName){
 
-        filesystem::path modulePath(name);
+        cnoid::stdx::filesystem::path modulePath(name);
         if(modulePath.is_absolute()){
             baseDirectoryType.select(BodyRTCItem::NO_BASE_DIRECTORY);
             if(modulePath.parent_path() == rtcDirectory){
                 baseDirectoryType.select(BodyRTCItem::RTC_DIRECTORY);
                 modulePath = modulePath.filename();
             } else {
-                filesystem::path projectDir(ProjectManager::instance()->currentProjectDirectory());
+                cnoid::stdx::filesystem::path projectDir(ProjectManager::instance()->currentProjectDirectory());
                 if(!projectDir.empty() && (modulePath.parent_path() == projectDir)){
                     baseDirectoryType.select(BodyRTCItem::BodyRTCItem::PROJECT_DIRECTORY);
                     modulePath = modulePath.filename();
@@ -824,11 +823,11 @@ bool BodyRTCItemImpl::restore(const Archive& archive)
 {
     string value;
     if(archive.read("moduleName", value)){
-        filesystem::path path(archive.expandPathVariables(value));
+        cnoid::stdx::filesystem::path path(archive.expandPathVariables(value));
         moduleName = getNativePathString(path);
     }
     if(archive.read("confFileName", value)){
-        filesystem::path path(archive.expandPathVariables(value));
+        cnoid::stdx::filesystem::path path(archive.expandPathVariables(value));
         confFileName = getNativePathString(path);
     }
     if(archive.read("configurationMode", value)){

--- a/src/OpenRTMPlugin/deprecated/BridgeConf.cpp
+++ b/src/OpenRTMPlugin/deprecated/BridgeConf.cpp
@@ -15,7 +15,6 @@
 using namespace std;
 using namespace cnoid;
 namespace program_options = boost::program_options;
-namespace filesystem = cnoid::stdx::filesystem;
 using fmt::format;
 
 
@@ -159,7 +158,7 @@ void BridgeConf::parseOptions()
         vector<string> values = vmap["module"].as<vector<string> >();
         for(size_t i=0; i < values.size(); ++i){
             string modulePath( values[i] );
-            if(filesystem::path(modulePath).extension().empty()){
+            if(cnoid::stdx::filesystem::path(modulePath).extension().empty()){
                 modulePath += string( SUFFIX_SHARED_EXT );
             }
             addModuleInfo( modulePath );
@@ -319,7 +318,7 @@ void BridgeConf::addModuleInfo(const std::string& value)
     } else {
         ModuleInfo info;
         info.fileName = parameters[0];
-        info.componentName = filesystem::path(info.fileName).stem().string();
+        info.componentName = cnoid::stdx::filesystem::path(info.fileName).stem().string();
         if(parameters.size() == 1){
             info.initFuncName = info.componentName + "Init";
         } else {

--- a/src/OpenRTMPlugin/pugixml/CMakeLists.txt
+++ b/src/OpenRTMPlugin/pugixml/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(headers
+  pugiconfig.hpp
+  pugixml.hpp
+  )
+
+
+choreonoid_set_header_files(HEADERS ${headers} INSTALL_HEADERS)


### PR DESCRIPTION
以下のOpenRTMPythonPluginを動作させるための修正を行った。

- https://github.com/Nobu19800/OpenRTMPythonPlugin

具体的な修正は以下の通り。

- OpenRTMPythonPluginのビルドに必要なヘッダーファイルのインストール
- RTSDiagramViewにmouseDoubleClickEventの追加(ビューのRTCをダブルクリックするときにOpenRTMPythonPluginの対応するRTCの編集画面を表示するための変更)