### PR TITLE
[openrtm1.1] Fix build for OpenRTM 1.1 with C++>=14

### DIFF
--- a/src/OpenRTMPlugin/BodyStateSubscriberRTCItem.cpp
+++ b/src/OpenRTMPlugin/BodyStateSubscriberRTCItem.cpp
@@ -23,7 +23,11 @@
 #ifdef USE_BUILTIN_CAMERA_IMAGE_IDL
 # include "deprecated/corba/CameraImage.hh"
 #else
-# include <rtm/idl/CameraCommonInterface.hh>
+  #if defined(OPENRTM_VERSION11)
+  # include <rtm/ext/CameraCommonInterface.hh>
+  #else
+  # include <rtm/idl/CameraCommonInterface.hh>
+  #endif
 #endif
 
 #include <rtm/DataInPort.h>

--- a/src/OpenRTMPlugin/RTMImageView.cpp
+++ b/src/OpenRTMPlugin/RTMImageView.cpp
@@ -14,7 +14,11 @@
 #ifdef USE_BUILTIN_CAMERA_IMAGE_IDL
 # include "deprecated/corba/CameraImage.hh"
 #else
-# include <rtm/idl/CameraCommonInterface.hh>
+  #if defined(OPENRTM_VERSION11)
+  # include <rtm/ext/CameraCommonInterface.hh>
+  #else
+  # include <rtm/idl/CameraCommonInterface.hh>
+  #endif
 #endif
 #include <rtm/DataInPort.h>
 

--- a/src/OpenRTMPlugin/SimulationExecutionContext.cpp
+++ b/src/OpenRTMPlugin/SimulationExecutionContext.cpp
@@ -29,7 +29,11 @@ SimulationExecutionContext::~SimulationExecutionContext()
 }
 
 
+#if defined(OPENRTM_VERSION11)
+void SimulationExecutionContext::tick() throw (CORBA::SystemException)
+#else
 void SimulationExecutionContext::tick()
+#endif
 {
 #if defined(OPENRTM_VERSION11)
     std::for_each(m_comps.begin(), m_comps.end(), invoke_worker());
@@ -39,13 +43,21 @@ void SimulationExecutionContext::tick()
 }
 
 
+#if defined(OPENRTM_VERSION11)
+int SimulationExecutionContext::svc(void) throw (CORBA::SystemException)
+#else
 int SimulationExecutionContext::svc(void)
+#endif
 {
     return 0;
 }
 
 
+#if defined(OPENRTM_VERSION11)
+RTC::ReturnCode_t SimulationExecutionContext::activate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException)
+#else
 RTC::ReturnCode_t SimulationExecutionContext::activate_component(RTC::LightweightRTObject_ptr comp)
+#endif
 {
 #if defined(OPENRTM_VERSION11)
 
@@ -91,7 +103,11 @@ RTC::ReturnCode_t SimulationExecutionContext::activate_component(RTC::Lightweigh
 }
 
 
+#if defined(OPENRTM_VERSION11)
+RTC::ReturnCode_t SimulationExecutionContext::deactivate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException)
+#else
 RTC::ReturnCode_t SimulationExecutionContext::deactivate_component(RTC::LightweightRTObject_ptr comp)
+#endif
 {
 #if defined(OPENRTM_VERSION11)
 
@@ -143,7 +159,11 @@ RTC::ReturnCode_t SimulationExecutionContext::deactivate_component(RTC::Lightwei
 }
 
 
+#if defined(OPENRTM_VERSION11)
+RTC::ReturnCode_t SimulationExecutionContext::reset_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException)
+#else
 RTC::ReturnCode_t SimulationExecutionContext::reset_component(RTC::LightweightRTObject_ptr comp)
+#endif
 {
 #if defined(OPENRTM_VERSION11)
 

--- a/src/OpenRTMPlugin/SimulationExecutionContext.h
+++ b/src/OpenRTMPlugin/SimulationExecutionContext.h
@@ -34,11 +34,19 @@ class SimulationExecutionContext : public RTC::OpenHRPExecutionContext
 public:
     SimulationExecutionContext();
     virtual ~SimulationExecutionContext(void);
+#ifdef OPENRTM_VERSION11
+    virtual void tick(void) throw(CORBA::SystemException) override;
+    virtual int svc(void) throw(CORBA::SystemException);
+    virtual RTC::ReturnCode_t activate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException) override;
+    virtual RTC::ReturnCode_t deactivate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException) override;
+    virtual RTC::ReturnCode_t reset_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException) override;
+#else
     virtual void tick(void) override;
     virtual int svc(void);
     virtual RTC::ReturnCode_t activate_component(RTC::LightweightRTObject_ptr comp) override;
     virtual RTC::ReturnCode_t deactivate_component(RTC::LightweightRTObject_ptr comp) override;
     virtual RTC::ReturnCode_t reset_component(RTC::LightweightRTObject_ptr comp) override;
+#endif
 };
 
 }

--- a/src/OpenRTMPlugin/deprecated/ChoreonoidExecutionContext.cpp
+++ b/src/OpenRTMPlugin/deprecated/ChoreonoidExecutionContext.cpp
@@ -30,7 +30,11 @@ ChoreonoidExecutionContext::~ChoreonoidExecutionContext()
 }
 
 
+#if defined(OPENRTM_VERSION11)
+void ChoreonoidExecutionContext::tick() throw(CORBA::SystemException)
+#else
 void ChoreonoidExecutionContext::tick()
+#endif
 {
 #if defined(OPENRTM_VERSION11)
     std::for_each(m_comps.begin(), m_comps.end(), invoke_worker());
@@ -40,13 +44,21 @@ void ChoreonoidExecutionContext::tick()
 }
 
 
+#if defined(OPENRTM_VERSION11)
+int ChoreonoidExecutionContext::svc(void) throw(CORBA::SystemException)
+#else
 int ChoreonoidExecutionContext::svc(void)
+#endif
 {
     return 0;
 }
 
 
+#if defined(OPENRTM_VERSION11)
+RTC::ReturnCode_t ChoreonoidExecutionContext::deactivate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException)
+#else
 RTC::ReturnCode_t ChoreonoidExecutionContext::deactivate_component(RTC::LightweightRTObject_ptr comp)
+#endif
 {
 #if defined(OPENRTM_VERSION11)
     RTC_TRACE(("deactivate_component()"));

--- a/src/OpenRTMPlugin/deprecated/ChoreonoidExecutionContext.h
+++ b/src/OpenRTMPlugin/deprecated/ChoreonoidExecutionContext.h
@@ -36,9 +36,16 @@ class ChoreonoidExecutionContext : public RTC::OpenHRPExecutionContext
 public:
     ChoreonoidExecutionContext();
     virtual ~ChoreonoidExecutionContext(void);
+#if defined(OPENRTM_VERSION11)
+    virtual void tick(void) throw(CORBA::SystemException) override;
+    virtual int svc(void) throw(CORBA::SystemException);
+    virtual RTC::ReturnCode_t deactivate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException) override;
+#else
     virtual void tick(void) override;
     virtual int svc(void);
     virtual RTC::ReturnCode_t deactivate_component(RTC::LightweightRTObject_ptr comp) override;
+#endif
+
 };
 
 }

--- a/src/OpenRTMPlugin/deprecated/ChoreonoidPeriodicExecutionContext.cpp
+++ b/src/OpenRTMPlugin/deprecated/ChoreonoidPeriodicExecutionContext.cpp
@@ -24,7 +24,11 @@ ChoreonoidPeriodicExecutionContext::~ChoreonoidPeriodicExecutionContext()
 }
 
 
+#if defined(OPENRTM_VERSION11)
+RTC::ReturnCode_t ChoreonoidPeriodicExecutionContext::deactivate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException)
+#else
 RTC::ReturnCode_t ChoreonoidPeriodicExecutionContext::deactivate_component(RTC::LightweightRTObject_ptr comp)
+#endif
 {
 #if defined(OPENRTM_VERSION11)
     RTC_TRACE(("deactivate_component()"));

--- a/src/OpenRTMPlugin/deprecated/ChoreonoidPeriodicExecutionContext.h
+++ b/src/OpenRTMPlugin/deprecated/ChoreonoidPeriodicExecutionContext.h
@@ -30,7 +30,11 @@ class ChoreonoidPeriodicExecutionContext : public virtual RTC_exp::PeriodicExecu
 public:
     ChoreonoidPeriodicExecutionContext();
     virtual ~ChoreonoidPeriodicExecutionContext(void);
+#if defined(OPENRTM_VERSION11)
+    virtual RTC::ReturnCode_t deactivate_component(RTC::LightweightRTObject_ptr comp) throw(CORBA::SystemException) override;
+#else
     virtual RTC::ReturnCode_t deactivate_component(RTC::LightweightRTObject_ptr comp) override;
+#endif
 };
 
 }

--- a/src/OpenRTMPlugin/deprecated/VirtualRobotPortHandler.cpp
+++ b/src/OpenRTMPlugin/deprecated/VirtualRobotPortHandler.cpp
@@ -8,7 +8,11 @@
 #ifdef USE_BUILTIN_CAMERA_IMAGE_IDL
 # include <deprecated/corba/CameraImage.hh>
 #else
-# include <rtm/idl/CameraCommonInterface.hh>
+  #if defined(OPENRTM_VERSION11)
+  # include <rtm/ext/CameraCommonInterface.hh>
+  #else
+  # include <rtm/idl/CameraCommonInterface.hh>
+  #endif
 #endif
 
 #include "VirtualRobotPortHandler.h"


### PR DESCRIPTION
When using OpenRTM 1.1, the various execution contexts interfaces declare
a looser throw() specification, which is now disallowed in C++14 and
above. In order to allow building with the latest choreonoid but using
older openrtm 1.1 versions this patch is necessary.

In addition this fixes the include path for `rtm/idl/CameraCommonInterface.hh` that used to be `rtm/ext/CameraCommonInterface.hh` in `openrtm1.1`

This shouldn't affect builds with more recent versions of OpenRTM but I haven't tested it.
Confirmed to work with our HRP robot simulations (including publishing of images over ROS).

