### PR TITLE
Choreonoid 2.3、Qt 6への対応

### DIFF
--- a/sample/PA10PickupControllerRTC.h
+++ b/sample/PA10PickupControllerRTC.h
@@ -6,9 +6,9 @@
 #ifndef PA10PickupControllerRTC_H
 #define PA10PickupControllerRTC_H
 
+#include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
-#include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/CorbaPort.h>
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>

--- a/sample/RobotIoRTC.cpp
+++ b/sample/RobotIoRTC.cpp
@@ -2,8 +2,8 @@
    @author Shin'ichiro Nakaoka
 */
 
-#include <cnoid/BodyIoRTC>
 #include <rtm/idl/BasicDataTypeSkel.h>
+#include <cnoid/BodyIoRTC>
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 

--- a/sample/SR1LiftupControllerRTC.h
+++ b/sample/SR1LiftupControllerRTC.h
@@ -6,9 +6,9 @@
 #ifndef SR1LiftupControllerRTC_H
 #define SR1LiftupControllerRTC_H
 
+#include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
-#include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/CorbaPort.h>
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>

--- a/sample/TankIoRTC.cpp
+++ b/sample/TankIoRTC.cpp
@@ -2,12 +2,12 @@
    @author Shin'ichiro Nakaoka
 */
 
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
 #include <cnoid/BodyIoRTC>
 #include <cnoid/AccelerationSensor>
 #include <cnoid/RateGyroSensor>
 #include <cnoid/Light>
-#include <rtm/idl/BasicDataTypeSkel.h>
-#include <rtm/idl/ExtendedDataTypesSkel.h>
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 

--- a/sample/TankJoystickControllerRTC.h
+++ b/sample/TankJoystickControllerRTC.h
@@ -5,10 +5,11 @@
 #ifndef TankJoystickControllerRTC_H
 #define TankJoystickControllerRTC_H
 
-#include <rtm/Manager.h>
-#include <rtm/DataFlowComponentBase.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>

--- a/sample/VisionSensorIoRTC.cpp
+++ b/sample/VisionSensorIoRTC.cpp
@@ -3,14 +3,14 @@
    @author Shizuko Hattori
 */
 
+#include <rtm/idl/InterfaceDataTypes.hh>
+#include <rtm/idl/CameraCommonInterface.hh>
+#include <cnoid/corba/PointCloud.hh>
 #include <cnoid/BodyIoRTC>
 #include <cnoid/RangeSensor>
 #include <cnoid/RangeCamera>
 #include <cnoid/ConnectionSet>
 #include <cnoid/ThreadPool>
-#include <rtm/idl/InterfaceDataTypes.hh>
-#include <rtm/idl/CameraCommonInterface.hh>
-#include <cnoid/corba/PointCloud.hh>
 #include <rtm/DataOutPort.h>
 #include <rtm/DataInPort.h>
 

--- a/src/OpenRTMPlugin/BodyIoRTCItem.cpp
+++ b/src/OpenRTMPlugin/BodyIoRTCItem.cpp
@@ -7,14 +7,13 @@
 #include <cnoid/BodyItem>
 #include <cnoid/ItemManager>
 #include <cnoid/MessageView>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include "gettext.h"
 
 #include "LoggerUtil.h"
 
 using namespace std;
 using namespace cnoid;
-using fmt::format;
 
 namespace cnoid {
 
@@ -240,7 +239,7 @@ bool BodyIoRTCItemImpl::createBodyIoRTC()
         bodyIoRTC = dynamic_cast<BodyIoRTC*>(self->rtc());
         if(!bodyIoRTC){
             mv->putln(
-                format(_("RTC \"{0}\" of {1} cannot be used as a BodyIoRTC because it is not derived from it."),
+                formatR(_("RTC \"{0}\" of {1} cannot be used as a BodyIoRTC because it is not derived from it."),
                        self->rtcModuleName(), self->name()),
                 MessageView::ERROR);
             self->deleteRTC(false);
@@ -255,14 +254,14 @@ bool BodyIoRTCItemImpl::createBodyIoRTC()
 
         if(!initialized){
             mv->putln(
-                format(_("RTC \"{0}\" of {1} failed to initialize."),
+                formatR(_("RTC \"{0}\" of {1} failed to initialize."),
                        self->rtcModuleName(), self->name()),
                 MessageView::ERROR);
             self->deleteRTC(true);
             return false;
         }
         
-        mv->putln(format(_("BodyIoRTC \"{}\" has been created."), self->rtcInstanceName()));
+        mv->putln(formatR(_("BodyIoRTC \"{}\" has been created."), self->rtcInstanceName()));
         
         return true;
     }

--- a/src/OpenRTMPlugin/BodyStateSubscriberRTCItem.cpp
+++ b/src/OpenRTMPlugin/BodyStateSubscriberRTCItem.cpp
@@ -3,9 +3,17 @@
    \author Shin'ichiro Nakaoka
 */
 
+#include <rtm/idl/InterfaceDataTypes.hh>
+#include <cnoid/corba/PointCloud.hh>
+#ifdef USE_BUILTIN_CAMERA_IMAGE_IDL
+# include "deprecated/corba/CameraImage.hh"
+#else
+# include <rtm/idl/CameraCommonInterface.hh>
+#endif
+
+
 #include "BodyStateSubscriberRTCItem.h"
 #include "OpenRTMUtil.h"
-#include <rtm/idl/InterfaceDataTypes.hh>
 #include <rtm/DataFlowComponentBase.h>
 #include <cnoid/BodyItem>
 #include <cnoid/RangeCamera>
@@ -16,15 +24,10 @@
 #include <cnoid/Config>
 #include <cnoid/MessageView>
 #include <cnoid/LazyCaller>
-#include <cnoid/corba/PointCloud.hh>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include <mutex>
 
-#ifdef USE_BUILTIN_CAMERA_IMAGE_IDL
-# include "deprecated/corba/CameraImage.hh"
-#else
-# include <rtm/idl/CameraCommonInterface.hh>
-#endif
+
 
 #include <rtm/DataInPort.h>
 
@@ -40,7 +43,6 @@
 
 using namespace std;
 using namespace cnoid;
-using fmt::format;
 
 namespace {
 
@@ -719,9 +721,9 @@ void BodyStateSubscriberRTCItemImpl::createRTC()
         "exec_cxt.periodic.type=PeriodicExecutionContext&"
         "exec_cxt.periodic.rate={1}");
     
-    RTC::RtcBase* rtc = createManagedRTC(format(param, self->name(), periodicRate));
+    RTC::RtcBase* rtc = createManagedRTC(formatR(param, self->name(), periodicRate));
     if(!rtc){
-        mv->putln(format(_("RTC for \"{}\" cannot be created."), self->name()), MessageView::ERROR);
+        mv->putln(formatR(_("RTC for \"{}\" cannot be created."), self->name()), MessageView::ERROR);
         return;
     }
 

--- a/src/OpenRTMPlugin/CMakeLists.txt
+++ b/src/OpenRTMPlugin/CMakeLists.txt
@@ -77,9 +77,8 @@ else()
   set(qt_wrap_cpp_files ${qt_wrap_cpp_files} RTSDiagramView.h)
 endif()  
 
-qt5_add_resources(RC_SRCS OpenRTMPlugin.qrc)
-
-qt5_wrap_cpp(qtsources ${qt_wrap_cpp_files})
+choreonoid_qt_add_resources(RC_SRCS OpenRTMPlugin.qrc)
+choreonoid_qt_wrap_cpp(qtsources ${qt_wrap_cpp_files})
 
 set(plugin_sources ${plugin_sources} ${qtsources})
 

--- a/src/OpenRTMPlugin/ControllerRTCItem.cpp
+++ b/src/OpenRTMPlugin/ControllerRTCItem.cpp
@@ -14,12 +14,11 @@
 #include <cnoid/ExecutablePath>
 #include <cnoid/FileUtil>
 #include <cnoid/CorbaUtil>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include "gettext.h"
 
 using namespace std;
 using namespace cnoid;
-using fmt::format;
 
 namespace {
 
@@ -310,7 +309,7 @@ std::string ControllerRTCItemImpl::getModuleFilename()
                 path = cnoid::stdx::filesystem::path(projectDir) / path;
             } else {
                 mv->putln(
-                    format(_("The rtc of {} cannot be generated because the project directory "
+                    formatR(_("The rtc of {} cannot be generated because the project directory "
                              "is not determined. Please save the project as a project file."),
                            self->name()),
                     MessageView::ERROR);
@@ -329,7 +328,7 @@ std::string ControllerRTCItemImpl::getModuleFilename()
         return path.string();
     } else {
         mv->putln(
-            format(_("RTC module file \"{0}\" of {1} does not exist."), path.string(), self->name()),
+            formatR(_("RTC module file \"{0}\" of {1} does not exist."), path.string(), self->name()),
             MessageView::ERROR);
     }
     
@@ -346,7 +345,7 @@ std::string ControllerRTCItem::getDefaultRTCInstanceName() const
 bool ControllerRTCItem::createRTC()
 {
     if(impl->createRTCmain()){
-        impl->mv->putln(format(_("BodyIoRTC \"{}\" has been created."), impl->rtcInstanceName));
+        impl->mv->putln(formatR(_("BodyIoRTC \"{}\" has been created."), impl->rtcInstanceName));
         return true;
     }
     return false;
@@ -379,7 +378,7 @@ bool ControllerRTCItemImpl::createRTCmain(bool isBodyIORTC) {
     }
     if(instanceBaseName.empty()){
         mv->putln(
-            format(_("The RTC instance name of {} is not specified."), self->name()),
+            formatR(_("The RTC instance name of {} is not specified."), self->name()),
             MessageView::ERROR);
         return false;
     }
@@ -391,11 +390,11 @@ bool ControllerRTCItemImpl::createRTCmain(bool isBodyIORTC) {
         if(manager.getComponent(rtcInstanceName.c_str()) == nullptr){
             break;
         }
-        rtcInstanceName = format("{0}({1})", instanceBaseName, index++);
+        rtcInstanceName = formatR("{0}({1})", instanceBaseName, index++);
     }
     if(index >= maxNumInstances){
         mv->putln(
-            format(_("RTC \"{0}\" of {1} is not created because more than "
+            formatR(_("RTC \"{0}\" of {1} is not created because more than "
                      "{2} existing instances have the same base name \"{3}\"."),
                    moduleName, self->name(), maxNumInstances, instanceBaseName),
             MessageView::ERROR);
@@ -408,21 +407,21 @@ bool ControllerRTCItemImpl::createRTCmain(bool isBodyIORTC) {
 
 #if defined(OPENRTM_VERSION11)
         option =
-            format("instance_name={0}&exec_cxt.periodic.type={1}&exec_cxt.periodic.rate={2}",
+            formatR("instance_name={0}&exec_cxt.periodic.type={1}&exec_cxt.periodic.rate={2}",
                    rtcInstanceName, execContextType.selectedSymbol(), periodicRate);
         DDEBUG("ControllerRTCItemImpl::createRTCmain OPENRTM_VERSION11");
 
 #elif defined(OPENRTM_VERSION12)
         if(isBodyIORTC){
             option =
-                format("instance_name={0}&execution_contexts=SimulationExecutionContext()&"
+                formatR("instance_name={0}&execution_contexts=SimulationExecutionContext()&"
                        "exec_cxt.periodic.type={1}&exec_cxt.periodic.rate={2}&"
                        "exec_cxt.sync_activation=NO&exec_cxt.sync_deactivation=NO",
                        rtcInstanceName, execContextType.selectedSymbol(), periodicRate);
             DDEBUG_V("ControllerRTCItemImpl::createRTCmain isBodyIORTC=TRUE  %s", option.c_str());
         } else {
             option =
-                format("instance_name={0}&"
+                formatR("instance_name={0}&"
                         "execution_contexts=SimulationExecutionContext(),SimulationPeriodicExecutionContext()&"
                         "exec_cxt.periodic.type={1}&exec_cxt.periodic.rate={2}&"
                         "exec_cxt.sync_activation=NO&exec_cxt.sync_deactivation=NO",
@@ -435,20 +434,20 @@ bool ControllerRTCItemImpl::createRTCmain(bool isBodyIORTC) {
 
 #if defined(OPENRTM_VERSION11)
           option =
-              format("instance_name={0}&exec_cxt.periodic.type={1}",
+              formatR("instance_name={0}&exec_cxt.periodic.type={1}",
                      rtcInstanceName, execContextType.selectedSymbol());
           DDEBUG("ControllerRTCItemImpl::createRTCmain OPENRTM_VERSION11");
 
 #elif defined(OPENRTM_VERSION12)
         if(isBodyIORTC){
             option =
-                format("instance_name={0}&execution_contexts=SimulationExecutionContext()&"
+                formatR("instance_name={0}&execution_contexts=SimulationExecutionContext()&"
                        "exec_cxt.periodic.type={1}&exec_cxt.sync_activation=NO&exec_cxt.sync_deactivation=NO",
                        rtcInstanceName, execContextType.selectedSymbol());
             DDEBUG_V("ControllerRTCItemImpl::createRTCmain isBodyIORTC=TRUE  %s", option.c_str());
         } else {
             option =
-                format("instance_name={0}&"
+                formatR("instance_name={0}&"
                        "execution_contexts=SimulationExecutionContext(),SimulationPeriodicExecutionContext()&"
                        "exec_cxt.periodic.type={1}&exec_cxt.sync_activation=NO&exec_cxt.sync_deactivation=NO",
                        rtcInstanceName, execContextType.selectedSymbol());
@@ -460,7 +459,7 @@ bool ControllerRTCItemImpl::createRTCmain(bool isBodyIORTC) {
 
     if(!rtc){
         mv->putln(
-            format(_("RTC \"{0}\" of {1} cannot be created by the RTC manager.\n"
+            formatR(_("RTC \"{0}\" of {1} cannot be created by the RTC manager.\n"
                      " RTC module file: \"{2}\"\n"
                      " Init function: {3}\n"
                      " option: {4}"),
@@ -523,7 +522,7 @@ void ControllerRTCItemImpl::deleteRTC(bool waitToBeDeleted)
         }
         if(!deleted){
             mv->putln(
-                format(_("RTC instance {0} of {1} cannot be deleted."),
+                formatR(_("RTC instance {0} of {1} cannot be deleted."),
                        rtcInstanceName, self->name()),
                 MessageView::WARNING);
         }
@@ -628,7 +627,7 @@ void ControllerRTCItemImpl::doPutProperties(PutPropertyFunction& putProperty)
 {
     FilePathProperty moduleProperty(
         moduleNameProperty,
-        { format(_("RT-Component module (*{})"), DLL_SUFFIX) });
+        { formatR(_("RT-Component module (*{})"), DLL_SUFFIX) });
 
     if(baseDirectoryType.is(RTC_DIRECTORY)){
         moduleProperty.setBaseDirectory(rtcDirectory.string());

--- a/src/OpenRTMPlugin/OpenRTMPlugin.cpp
+++ b/src/OpenRTMPlugin/OpenRTMPlugin.cpp
@@ -40,7 +40,7 @@
 #include <cnoid/FileUtil>
 #include <QTcpSocket>
 #include <cnoid/AppConfig>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include <rtm/ComponentActionListener.h>
 #include <set>
 
@@ -51,8 +51,6 @@
 
 using namespace std;
 using namespace cnoid;
-using fmt::format;
-
 namespace {
 
 class ManagerEx : public RTC::Manager
@@ -112,9 +110,9 @@ public:
             ::coil::Creator<::RTC::ExecutionContextBase, ExecutionContextType>,
             ::coil::Destructor<::RTC::ExecutionContextBase, ExecutionContextType>) == coil::FactoryReturn::OK) {
 #endif
-            mv->putln(format(_("{} has been registered."), name));
+            mv->putln(formatR(_("{} has been registered."), name));
         } else {
-            mv->putln(format(_("Failed to register {}."), name), MessageView::WARNING);
+            mv->putln(formatR(_("Failed to register {}."), name), MessageView::WARNING);
         }
     }
 
@@ -327,7 +325,7 @@ public:
                 mv->notify(_("An RT component which is not managed by Choreonoid is being deleted."));
             } else {
                 mv->notify(
-                    format(_("{} RT components which are not managed by Choreonoid are being deleted."),
+                    formatR(_("{} RT components which are not managed by Choreonoid are being deleted."),
                            n));
             }
             mv->flush();
@@ -574,7 +572,7 @@ bool cnoid::deleteRTC(RTC::RtcBase* rtc)
 
         } catch (CORBA::SystemException& ex) {
             MessageView::instance()->putln(
-                format(_("CORBA {0} ({1}), {2} in cnoid::deleteRTC()."),
+                formatR(_("CORBA {0} ({1}), {2} in cnoid::deleteRTC()."),
                        ex._name(), ex._rep_id(), ex.NP_minorString()),
                 MessageView::WARNING);
         }

--- a/src/OpenRTMPlugin/OpenRTMUtil.h
+++ b/src/OpenRTMPlugin/OpenRTMUtil.h
@@ -39,7 +39,7 @@ typename ServiceType::_ptr_type findRTCService(RTC::RTObject_ptr rtc, const std:
     return CORBA::is_nil(obj) ? ServiceType::_nil() : ServiceType::_narrow(obj);
 }
 
-template<> CNOID_EXPORT CORBA::Object::_ptr_type findRTCService<CORBA::Object>(RTC::RTObject_ptr rtc, const std::string& name);
+template<> /*CNOID_EXPORT*/ CORBA::Object::_ptr_type findRTCService<CORBA::Object>(RTC::RTObject_ptr rtc, const std::string& name);
 
 }
 

--- a/src/OpenRTMPlugin/RTCItem.cpp
+++ b/src/OpenRTMPlugin/RTCItem.cpp
@@ -15,14 +15,13 @@
 #include <cnoid/PutPropertyFunction>
 #include <cnoid/Archive>
 #include <rtm/RTObject.h>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include "gettext.h"
 
 #include "LoggerUtil.h"
 
 using namespace std;
 using namespace cnoid;
-using fmt::format;
 
 namespace {
 const bool TRACE_FUNCTIONS = false;
@@ -225,7 +224,7 @@ void RTCItem::doPutProperties(PutPropertyFunction& putProperty)
 
     FilePathProperty moduleProperty(
         moduleName,
-        { format(_("RT-Component module (*{})"), DLL_SUFFIX) });
+        { formatR(_("RT-Component module (*{})"), DLL_SUFFIX) });
 
     if (baseDirectoryType.is(RTC_DIRECTORY)) {
         moduleProperty.setBaseDirectory(rtcDirectory.string());
@@ -379,7 +378,7 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
                 string initFunc(componentName + "Init");
                 setupModules(actualFilename, initFunc, componentName, prop);
             } else {
-                mv->putln(MessageView::ERROR,format(_("File \"{}\" of RTC \"{}\" does not exist."), dllPath.string(), componentName));
+                mv->putln(MessageView::ERROR, formatR(_("File \"{}\" of RTC \"{}\" does not exist."), dllPath.string(), componentName));
             }
         }
     }
@@ -387,9 +386,9 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
     bool created = isValid();
 
     if (created) {
-        mv->putln(format(_("RTC \"{0}\" has been created from \"{1}\"."), componentName, actualFilename));
+        mv->putln(formatR(_("RTC \"{0}\" has been created from \"{1}\"."), componentName, actualFilename));
     } else {
-        mv->putln(MessageView::ERROR, format(_("RTC \"{}\" cannot be created."), componentName));
+        mv->putln(MessageView::ERROR, formatR(_("RTC \"{}\" cannot be created."), componentName));
     }
 
     return created;
@@ -415,7 +414,7 @@ void RTComponentImpl::setupModules(string& fileName, string& initFuncName, strin
 
     if (!rtc_) {
         mv->putln(
-            format(_("RTC \"{0}\" cannot be created by the RTC manager.\n"
+            formatR(_("RTC \"{0}\" cannot be created by the RTC manager.\n"
                      " RTC module file: \"{1}\"\n"
                      " Init function: {2}\n"
                      " option: {3}"),
@@ -477,9 +476,9 @@ void RTComponentImpl::createProcess(string& command, PropertyMap& prop)
     rtcProcess.start(command.c_str(), argv);
 #endif
     if (!rtcProcess.waitForStarted()) {
-        mv->putln(format(_("RT Component process \"{}\" cannot be executed."), command));
+        mv->putln(formatR(_("RT Component process \"{}\" cannot be executed."), command));
     } else {
-        mv->putln(format(_("RT Component process \"{}\" has been executed."), command));
+        mv->putln(formatR(_("RT Component process \"{}\" has been executed."), command));
         rtcProcess.sigReadyReadStandardOutput().connect(
             [&](){ onReadyReadServerProcessOutput(); });
     }
@@ -499,14 +498,14 @@ void RTComponentImpl::deleteRTC()
 {
     if (rtc_) {
         string rtcName(rtc_->getInstanceName());
-        mv->putln(format(_("delete {}"), rtcName));
+        mv->putln(formatR(_("delete {}"), rtcName));
         if (!cnoid::deleteRTC(rtc_)) {
-            mv->putln(format(_("{} cannot be deleted."), rtcName));
+            mv->putln(formatR(_("{} cannot be deleted."), rtcName));
         }
         rtc_ = nullptr;
 
     } else if (rtcProcess.state() != QProcess::NotRunning) {
-        mv->putln(format(_("delete {}"), componentName));
+        mv->putln(formatR(_("delete {}"), componentName));
         rtcProcess.kill();
         rtcProcess.waitForFinished(100);
     }

--- a/src/OpenRTMPlugin/RTMImageView.cpp
+++ b/src/OpenRTMPlugin/RTMImageView.cpp
@@ -2,30 +2,30 @@
    @author Shin'ichiro Nakaoka
 */
 
+#include <rtm/idl/BasicDataTypeSkel.h>
+#ifdef USE_BUILTIN_CAMERA_IMAGE_IDL
+# include "deprecated/corba/CameraImage.hh"
+#else
+# include <rtm/idl/CameraCommonInterface.hh>
+#endif
+
 #include "RTMImageView.h"
 #include "OpenRTMUtil.h"
 #include <cnoid/ImageWidget>
 #include <cnoid/ViewManager>
 #include <cnoid/LazyCaller>
 #include <cnoid/CorbaUtil>
-#include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/DataFlowComponentBase.h>
 
-#ifdef USE_BUILTIN_CAMERA_IMAGE_IDL
-# include "deprecated/corba/CameraImage.hh"
-#else
-# include <rtm/idl/CameraCommonInterface.hh>
-#endif
 #include <rtm/DataInPort.h>
 
 #include <QBoxLayout>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include "gettext.h"
 
 using namespace std;
 using namespace cnoid;
 using namespace RTC;
-using fmt::format;
 
 namespace {
 
@@ -140,7 +140,7 @@ void RTMImageViewImpl::createRTC(const std::string& name)
     deleteRTC();
 
     auto args =
-        format("ImageView?instance_name={}&"
+        formatR("ImageView?instance_name={}&"
                "exec_cxt.periodic.type=PeriodicExecutionContext&exec_cxt.periodic.rate=30",
                self->name());
 

--- a/src/OpenRTMPlugin/RTSConfigurationView.cpp
+++ b/src/OpenRTMPlugin/RTSConfigurationView.cpp
@@ -158,7 +158,7 @@ RTSConfigurationViewImpl::RTSConfigurationViewImpl(RTSConfigurationView* self)
     QHBoxLayout* compNameLayout = new QHBoxLayout(frmCompName);
     compNameLayout->addWidget(lblCompName);
     compNameLayout->addWidget(txtCompName_);
-    compNameLayout->setMargin(0);
+    compNameLayout->setContentsMargins(0, 0, 0, 0);
 
     lstConfigSet_ = new QTableWidget(0, 2);
     lstConfigSet_->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -189,14 +189,14 @@ RTSConfigurationViewImpl::RTSConfigurationViewImpl(RTSConfigurationView* self)
     setBtnLayout->addWidget(btnSetAdd);
     setBtnLayout->addWidget(btnSetDelete);
     setBtnLayout->addWidget(chkSetDetail_);
-    setBtnLayout->setMargin(1);
+    setBtnLayout->setContentsMargins(1, 1, 1, 1);
 
     QFrame* frmConfSet = new QFrame;
     QVBoxLayout* confSetLayout = new QVBoxLayout(frmConfSet);
     confSetLayout->addWidget(frmCompName);
     confSetLayout->addWidget(lstConfigSet_);
     confSetLayout->addWidget(frmSetButtons);
-    confSetLayout->setMargin(3);
+    confSetLayout->setContentsMargins(3, 3, 3, 3);
 
 
     QLabel* lblConfSet = new QLabel(_("Configuration Set : "));
@@ -207,7 +207,7 @@ RTSConfigurationViewImpl::RTSConfigurationViewImpl(RTSConfigurationView* self)
     QHBoxLayout* configLayout = new QHBoxLayout(frmConfig);
     configLayout->addWidget(lblConfSet);
     configLayout->addWidget(txtConfSetName_);
-    configLayout->setMargin(0);
+    configLayout->setContentsMargins(0, 0, 0, 0);
 
     lstDetail_ = new QTableWidget(0, 2);
     lstDetail_->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -236,14 +236,14 @@ RTSConfigurationViewImpl::RTSConfigurationViewImpl(RTSConfigurationView* self)
     btnLayout->addWidget(btnAdd);
     btnLayout->addWidget(btnDelete);
     btnLayout->addWidget(chkDetail_);
-    btnLayout->setMargin(1);
+    btnLayout->setContentsMargins(1, 1, 1, 1);
 
     QFrame* frmDetail = new QFrame;
     QVBoxLayout* detailLayout = new QVBoxLayout(frmDetail);
     detailLayout->addWidget(frmConfig);
     detailLayout->addWidget(lstDetail_);
     detailLayout->addWidget(frmButtons);
-    detailLayout->setMargin(3);
+    detailLayout->setContentsMargins(3, 3, 3, 3);
 
     QSplitter* splitter = new QSplitter(Qt::Orientation::Horizontal);
     splitter->addWidget(frmConfSet);
@@ -264,7 +264,7 @@ RTSConfigurationViewImpl::RTSConfigurationViewImpl(RTSConfigurationView* self)
     QHBoxLayout* mainLayout = new QHBoxLayout;
     mainLayout->addWidget(splitter);
     mainLayout->addWidget(frmMainButtons);
-    mainLayout->setMargin(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
 
     setLayout(mainLayout);
 
@@ -431,9 +431,9 @@ void RTSConfigurationViewImpl::showConfigurationView()
         itemName->setText(param->getName());
         itemName->setData(Qt::UserRole, param->getId());
         if (param->isChangedName()) {
-            lstDetail_->item(row, 0)->setBackgroundColor("#FFC0C0");
+            lstDetail_->item(row, 0)->setBackground(QColor("#FFC0C0"));
         } else {
-            lstDetail_->item(row, 0)->setBackgroundColor(Qt::white);
+            lstDetail_->item(row, 0)->setBackground(Qt::white);
         }
 
         QTableWidgetItem* itemValue = new QTableWidgetItem;
@@ -441,9 +441,9 @@ void RTSConfigurationViewImpl::showConfigurationView()
         itemValue->setText(param->getValue());
         itemValue->setData(Qt::UserRole, param->getId());
         if (param->isChangedValue()) {
-            lstDetail_->item(row, 1)->setBackgroundColor("#FFC0C0");
+            lstDetail_->item(row, 1)->setBackground(QColor("#FFC0C0"));
         } else {
-            lstDetail_->item(row, 1)->setBackgroundColor(Qt::white);
+            lstDetail_->item(row, 1)->setBackground(Qt::white);
         }
     }
 }
@@ -573,9 +573,9 @@ void RTSConfigurationViewImpl::showConfigurationSetView()
         itemName->setText(param->getName());
         itemName->setData(Qt::UserRole, param->getId());
         if (param->isChangedName()) {
-            lstConfigSet_->item(row, 1)->setBackgroundColor("#FFC0C0");
+            lstConfigSet_->item(row, 1)->setBackground(QColor("#FFC0C0"));
         } else {
-            lstConfigSet_->item(row, 1)->setBackgroundColor(Qt::white);
+            lstConfigSet_->item(row, 1)->setBackground(Qt::white);
         }
     }
 
@@ -657,9 +657,9 @@ void RTSConfigurationViewImpl::updateConfigSet()
     (*targetConf)->setChanged();
 
     if ((*targetConf)->isChangedName()) {
-        lstConfigSet_->item(row, 1)->setBackgroundColor("#FFC0C0");
+        lstConfigSet_->item(row, 1)->setBackground(QColor("#FFC0C0"));
     } else {
-        lstConfigSet_->item(row, 1)->setBackgroundColor(Qt::white);
+        lstConfigSet_->item(row, 1)->setBackground(Qt::white);
     }
 }
 
@@ -675,9 +675,9 @@ void RTSConfigurationViewImpl::activeSetChanged()
             if( rowId==targetSet->getId()) {
                 DDEBUG_V("index:%d, row:%d", index, idxRow);
                 if (targetSet->isChangedActive()) {
-                    lstConfigSet_->item(idxRow, 0)->setBackgroundColor("#FFC0C0");
+                    lstConfigSet_->item(idxRow, 0)->setBackground(QColor("#FFC0C0"));
                 } else {
-                    lstConfigSet_->item(idxRow, 0)->setBackgroundColor(Qt::white);
+                    lstConfigSet_->item(idxRow, 0)->setBackground(Qt::white);
                 }
                 break;
             }
@@ -714,13 +714,13 @@ void RTSConfigurationViewImpl::updateDetail()
     currentSet_->setChanged();
 
     if ((*targetConf)->isChangedName()) {
-        lstDetail_->item(row, 0)->setBackgroundColor("#FFC0C0");
+        lstDetail_->item(row, 0)->setBackground(QColor("#FFC0C0"));
     } else {
-        lstDetail_->item(row, 0)->setBackgroundColor(Qt::white);
+        lstDetail_->item(row, 0)->setBackground(Qt::white);
     }
     if ((*targetConf)->isChangedValue()) {
-        lstDetail_->item(row, 1)->setBackgroundColor("#FFC0C0");
+        lstDetail_->item(row, 1)->setBackground(QColor("#FFC0C0"));
     } else {
-        lstDetail_->item(row, 1)->setBackgroundColor(Qt::white);
+        lstDetail_->item(row, 1)->setBackground(Qt::white);
     }
 }

--- a/src/OpenRTMPlugin/RTSDiagramView.cpp
+++ b/src/OpenRTMPlugin/RTSDiagramView.cpp
@@ -26,7 +26,7 @@
 #include <QBoxLayout>
 #include <QDragEnterEvent>
 #include <QMessageBox>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include "gettext.h"
 
 using namespace cnoid;
@@ -903,7 +903,7 @@ void RTSDiagramViewImpl::dropEvent(QDropEvent *event)
     for (list<NamingContextHelper::ObjectInfo>::iterator it = nsViewSelections.begin(); it != nsViewSelections.end(); it++) {
         NamingContextHelper::ObjectInfo& info = *it;
         if (!info.isAlive_) {
-            MessageView::instance()->putln(fmt::format(_("{} is not alive"), info.id_));
+            MessageView::instance()->putln(formatR(_("{} is not alive"), info.id_));
         } else {
             addRTSComp(info, mapToScene(event->pos()));
             DDEBUG_V("%s", info.getFullPath().c_str());
@@ -1125,7 +1125,7 @@ void RTSDiagramViewImpl::mouseReleaseEvent(QMouseEvent *event)
 
 void RTSDiagramViewImpl::wheelEvent(QWheelEvent* event)
 {
-    double dSteps = (double)event->delta() / 120.0;
+    double dSteps = (double)event->angleDelta().y() / 120.0;
     double scaleVal = 1.0;
     scaleVal -= (dSteps / 20.0);
     scale(scaleVal, scaleVal);

--- a/src/OpenRTMPlugin/RTSNameServerView.cpp
+++ b/src/OpenRTMPlugin/RTSNameServerView.cpp
@@ -671,7 +671,7 @@ void RTSNameTreeWidget::mouseMoveEvent(QMouseEvent *event)
     QDrag *drag = new QDrag(this);
     drag->setPixmap(QPixmap(":/Corba/icons/NSRTC.png"));
     drag->setMimeData(mimeData);
-    drag->start(Qt::MoveAction);
+    drag->exec(Qt::MoveAction);
 }
 
 

--- a/src/OpenRTMPlugin/RTSystemItem.cpp
+++ b/src/OpenRTMPlugin/RTSystemItem.cpp
@@ -7,14 +7,13 @@
 #include <cnoid/AppConfig>
 #include <cnoid/PutPropertyFunction>
 #include <rtm/CORBA_SeqUtil.h>
-#include <fmt/format.h>
+#include <cnoid/Format>
 #include "LoggerUtil.h"
 #include "gettext.h"
 
 using namespace cnoid;
 using namespace std;
 using namespace RTC;
-using fmt::format;
 
 namespace cnoid {
 
@@ -497,7 +496,7 @@ bool RTSComp::connectionCheckSub(RTSPort* rtsPort)
             }
             catch (CORBA::SystemException& ex) {
                 MessageView::instance()->putln(
-                    format(_("CORBA {0} ({1}), {2} in RTSComp::connectionCheckSub()"),
+                    formatR(_("CORBA {0} ({1}), {2} in RTSComp::connectionCheckSub()"),
                            ex._name(), ex._rep_id(), ex.NP_minorString()),
                     MessageView::WARNING);
                 continue;
@@ -563,7 +562,7 @@ bool RTSComp::getComponentPath(RTC::PortService_ptr source, std::string& out_pat
         }
         catch (CORBA::SystemException& ex) {
             MessageView::instance()->putln(
-                format(_("CORBA {0} ({1}), {2} in RTSComp::getComponentPath()"),
+                formatR(_("CORBA {0} ({1}), {2} in RTSComp::getComponentPath()"),
                        ex._name(), ex._rep_id(), ex.NP_minorString()),
                 MessageView::WARNING);
             return false;


### PR DESCRIPTION
Choreonoid 2.3、Qt 6向けの修正を行った。

- `fmt::format`を`cnoid::formatR`に変更
- Qt5からQt6の仕様変更への対応
  - `QTableWidgetItem::setBackgroundColor` → `QTableWidgetItem::setBackground`
  - `QHBoxLayout::setMargin` → `QHBoxLayout::setContentsMargins`
  - `QWheelEvent::delta` → `QWheelEvent::angleDelta().y`
  - `QDrag::start` → `QDrag::exec`
 - CMakeLists.txtで`qt5_add_resources`、`qt5_wrap_cpp`を`choreonoid_qt_add_resources`、`choreonoid_qt_wrap_cpp`に変更