### PR TITLE
実行ファイルから起動したRTCのシミュレーション開始時アクティブ化、終了時非アクティブ化、ファイルパス再設定時の再起動を実装

### DIFF
--- a/src/OpenRTMPlugin/RTCItem.cpp
+++ b/src/OpenRTMPlugin/RTCItem.cpp
@@ -44,6 +44,7 @@ public:
     bool createRTC(PropertyMap& properties);
     bool isValid() const;
     void setupModules(string& fileName, string& initFuncName, string& componentName, PropertyMap& properties);
+    const bool runningProcess() const;
     void createProcess(string& command, PropertyMap& properties);
     void deleteRTC();
     void activate();
@@ -168,10 +169,15 @@ Item* RTCItem::doDuplicate() const
 
 void RTCItem::setModuleName(const std::string& name)
 {
+    mv->putln(_("setModuleName."));
     DDEBUG_V("RTCItem::setModuleName %s", name.c_str());
     if (moduleName != name) {
         moduleName = name;
         updateRTCInstance();
+    }
+    else if (rtcomp->runningProcess())
+    {
+        updateRTCInstance(true);
     }
 }
 
@@ -453,13 +459,24 @@ const std::string& RTComponent::name() const
 }
 
 
+const bool RTComponent::runningProcess() const
+{
+    return impl->runningProcess();
+}
+
+const bool RTComponentImpl::runningProcess() const
+{
+    return (rtcProcess.state() != QProcess::NotRunning);
+}
+
+
 void RTComponentImpl::createProcess(string& command, PropertyMap& prop)
 {
     DDEBUG("RTComponent::createProcess");
 
     QStringList argv;
     argv.push_back(QString("-o"));
-    argv.push_back(QString("naming.formats: %n.rtc"));
+    argv.push_back(QString("naming.formats: choreonoid.host_cxt/%n.rtc"));
     argv.push_back(QString("-o"));
     argv.push_back(QString("logger.enable: NO"));
     for (PropertyMap::iterator it = prop.begin(); it != prop.end(); it++) {
@@ -467,6 +484,7 @@ void RTComponentImpl::createProcess(string& command, PropertyMap& prop)
         argv.push_back(QString(string(it->first + ":" + it->second).c_str()));
     }
     if (rtcProcess.state() != QProcess::NotRunning) {
+        mv->putln(formatR(_("RTComponent kill")));
         rtcProcess.kill();
         rtcProcess.waitForFinished(100);
     }

--- a/src/OpenRTMPlugin/RTCItem.h
+++ b/src/OpenRTMPlugin/RTCItem.h
@@ -31,6 +31,7 @@ public:
     bool isValid() const;
     const std::string& name() const;
     void activate();
+    const bool runningProcess() const;
 
 private:
     RTComponentImpl* impl;

--- a/src/OpenRTMPlugin/RTSystemItem.cpp
+++ b/src/OpenRTMPlugin/RTSystemItem.cpp
@@ -7,6 +7,8 @@
 #include <cnoid/AppConfig>
 #include <cnoid/PutPropertyFunction>
 #include <rtm/CORBA_SeqUtil.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include <rtm/CorbaNaming.h>
 #include <cnoid/Format>
 #include "LoggerUtil.h"
 #include "gettext.h"
@@ -99,6 +101,10 @@ public:
 
     void changeStateCheck();
     void changePollingPeriod(int value);
+
+    bool start();
+    void stop();
+    RTCList* getRTCList();
 
 private:
     void setStateCheckMethod(int value);
@@ -625,7 +631,7 @@ RTSystemItemImpl::RTSystemItemImpl(RTSystemItem* self)
 
 
 RTSystemItem::RTSystemItem(const RTSystemItem& org)
-    : Item(org)
+    : cnoid::ControllerItem(org)
 {
     impl = new RTSystemItemImpl(this, *org.impl);
 }
@@ -1121,6 +1127,111 @@ void RTSystemItemImpl::changeStateCheck()
     }
 }
 
+RTCList* RTSystemItemImpl::getRTCList()
+{
+    RTCList_var crtcs = new RTCList();
+    auto& manager = RTC::Manager::instance();
+    try
+    {
+        CorbaNaming cns(manager.theORB(), "localhost:2809");
+        CORBA::Object_var obj = cns.resolveStr("choreonoid.host_cxt");
+        try
+        {
+            CosNaming::NamingContext_var choreonoid_context = CosNaming::NamingContext::
+                _narrow(obj);
+            CORBA::ULong length = 500;
+            CosNaming::BindingList_var bl;
+            CosNaming::BindingIterator_var bi;
+            choreonoid_context->list(length, bl, bi);
+            CORBA::ULong len(bl->length());
+            for (CORBA::ULong i = 0; i < len; ++i)
+            {
+                if (bl[i].binding_type == CosNaming::nobject)
+                {
+                    if (std::string(bl[i].binding_name[0].kind) == "rtc")
+                    {
+                        try
+                        {
+                            RTC::RTObject_var rtc = RTC::RTObject::_narrow(choreonoid_context->resolve(bl[i].binding_name));
+                            if (!rtc->_non_existent())
+                            {
+                                CORBA_SeqUtil::push_back(crtcs.inout(), rtc._retn());
+                            }
+                        }
+                        catch (...)
+                        {
+
+                        }
+                    }
+                }
+            }
+        }
+        catch (CosNaming::NamingContext::NotFound& e)
+        {
+            MessageView::instance()->putln(
+                formatR(_("NOT FOUND: {0}."),
+                    cns.toString(e.rest_of_name)), MessageView::WARNING);
+            return crtcs._retn();
+        }
+        catch (CosNaming::NamingContext::CannotProceed& e)
+        {
+            MessageView::instance()->putln(
+                formatR(_("Cannot proceed: {0}."),
+                    cns.toString(e.rest_of_name)), MessageView::WARNING);
+            return crtcs._retn();
+        }
+        catch (CosNaming::NamingContext::InvalidName& /*e*/)
+        {
+            MessageView::instance()->putln(
+                formatR(_("Invalid name: choreonoid.")), MessageView::WARNING);
+            return crtcs._retn();
+        }
+
+    }
+    catch (...)
+    {
+        return crtcs._retn();
+    }
+    return crtcs._retn();
+}
+
+bool RTSystemItemImpl::start()
+{
+    RTC::RTCList rtc_list = *getRTCList();
+
+    for (CORBA::ULong i = 0; i < rtc_list.length(); i++)
+    {
+        RTC::RTObject_var rtc = RTObject::_duplicate(rtc_list[i]);
+        if (CORBA_RTCUtil::is_in_error(rtc.inout()))
+        {
+            CORBA_RTCUtil::reset(rtc.inout());
+        }
+        if (CORBA_RTCUtil::is_in_inactive(rtc.inout()))
+        {
+            CORBA_RTCUtil::activate(rtc.inout());
+        }
+    }
+    return true;
+}
+
+void RTSystemItemImpl::stop()
+{
+    RTC::RTCList rtc_list = *getRTCList();
+
+    for (CORBA::ULong i = 0; i < rtc_list.length(); i++)
+    {
+        RTC::RTObject_var rtc = RTObject::_duplicate(rtc_list[i]);
+        if (CORBA_RTCUtil::is_in_error(rtc.inout()))
+        {
+            CORBA_RTCUtil::reset(rtc.inout());
+        }
+        if (CORBA_RTCUtil::is_in_active(rtc.inout()))
+        {
+            CORBA_RTCUtil::deactivate(rtc.inout());
+        }
+    }
+}
+
 bool RTSystemItem::loadRtsProfile(const string& filename)
 {
     DDEBUG_V("RTSystemItem::loadRtsProfile=%s", filename.c_str());
@@ -1400,4 +1511,14 @@ SignalProxy<void(int)> RTSystemItem::sigTimerPeriodChanged()
 SignalProxy<void(bool)> RTSystemItem::sigTimerChanged()
 {
     return impl->sigTimerChanged;
+}
+
+bool RTSystemItem::start()
+{
+    return impl->start();
+}
+
+void RTSystemItem::stop()
+{
+    impl->stop();
 }

--- a/src/OpenRTMPlugin/RTSystemItem.h
+++ b/src/OpenRTMPlugin/RTSystemItem.h
@@ -2,6 +2,7 @@
 #define CNOID_OPENRTM_PLUGIN_RT_SYSTEM_ITEM_H
 
 #include <cnoid/Item>
+#include <cnoid/ControllerItem>
 #include <cnoid/EigenUtil>
 #include <cnoid/IdPair>
 #include <cnoid/CorbaUtil>
@@ -23,7 +24,7 @@ class RTSystemItemImpl;
 /*!
  * @brief This is the RTSystem item.
  */
-class CNOID_EXPORT RTSystemItem : public Item, public RTSystem
+class CNOID_EXPORT RTSystemItem : public cnoid::ControllerItem, public RTSystem
 {
 public:
     typedef cnoid::IdPair<RTSPort*> RTSPortPair;
@@ -60,6 +61,9 @@ public:
 
     SignalProxy<void(int)> sigTimerPeriodChanged();
     SignalProxy<void(bool)> sigTimerChanged();
+
+    virtual bool start() override;
+    virtual void stop() override;
 
 protected:
     virtual Item* doDuplicate() const override;


### PR DESCRIPTION
RTCItemでRTC moduleに実行ファイルを指定した場合にシミュレーション開始時アクティブ化、終了時非アクティブ化するように変更した。下記の通り、RTCが`choreonoid.host_cxt`以下に登録され、それらのRTCがアクティブ化される。

- #19 

また、RTC moduleのファイルパスの再設定時にプロセスを強制終了し、RTCを再起動するように変更した。