### PR TITLE
プロジェクトファイルのフォルダにRTCモジュールを入れる場合に発生する不具合修正

### DIFF
--- a/src/OpenRTMPlugin/RTCItem.cpp
+++ b/src/OpenRTMPlugin/RTCItem.cpp
@@ -267,6 +267,8 @@ bool RTCItem::store(Archive& archive)
 bool RTCItem::restore(const Archive& archive)
 {
     DDEBUG("RTCItem::restore");
+    
+    projectDirectory = archive.projectDirectory();
 
     if (!Item::restore(archive)) {
         return false;
@@ -306,8 +308,15 @@ bool RTCItem::convertAbsolutePath()
         } else if (baseDirectoryType.is(PROJECT_DIRECTORY)) {
             string projectDir = ProjectManager::instance()->currentProjectDirectory();
             if (projectDir.empty()) {
-                mv->putln(_("Please save the project."));
-                return false;
+                if(projectDirectory.empty())
+                {
+                    mv->putln(_("Please save the project."));
+                    return false;
+                }
+                else
+                {
+                    modulePath = cnoid::stdx::filesystem::path(projectDirectory) / modulePath;
+                }
             } else {
                 modulePath = cnoid::stdx::filesystem::path(projectDir) / modulePath;
             }

--- a/src/OpenRTMPlugin/RTCItem.h
+++ b/src/OpenRTMPlugin/RTCItem.h
@@ -91,6 +91,7 @@ private:
     int oldBaseDirectoryType;
     stdx::filesystem::path rtcDirectory;
     stdx::filesystem::path modulePath;
+    stdx::filesystem::path projectDirectory;
     bool isActivationEnabled_;
 
     void deleteRTCInstance();


### PR DESCRIPTION
プロジェクトファイルのフォルダにRTCモジュールを入れる場合に、`ProjectManager::instance()->currentProjectDirectory()`で取得するプロジェクトファイルのフォルダのパスは、全てのアイテムを設定後でないと取得できないため、RTCモジュールのパスが正しく設定されない。

変数archiveからプロジェクトファイルのフォルダのパスを取得するように変更した。ただし手動でベースディレクトリの項目を`Project directory`に設定する必要がある。