### PR TITLE
プロジェクトロード時のRTC起動、シミュレーション開始時のアクティブ化の処理修正

### DIFF
--- a/src/OpenRTMPlugin/ControllerRTCItem.cpp
+++ b/src/OpenRTMPlugin/ControllerRTCItem.cpp
@@ -81,6 +81,11 @@ public:
     void doPutProperties(PutPropertyFunction& putProperty);
     bool store(Archive& archive);
     bool restore(const Archive& archive);
+    
+ private:     
+    void setBaseDirectoryType(std::filesystem::path& projectDirectory);
+    std::filesystem::path getModuleFullPath(std::filesystem::path& modulePath);
+    std::filesystem::path projectDirectoryPath;
 };
 
 }
@@ -187,8 +192,63 @@ void ControllerRTCItem::setRTCModule(const std::string& name)
 }
 
 
+void ControllerRTCItemImpl::setBaseDirectoryType(std::filesystem::path& projectDirectory)
+{
+	std::filesystem::path modulePath(moduleNameProperty);
+	if (modulePath.is_absolute()) {
+		auto rel = std::filesystem::weakly_canonical(modulePath).lexically_relative(std::filesystem::weakly_canonical(projectDirectory));
+		if(!rel.empty() && *rel.begin() != "..")
+		{
+			baseDirectoryType.select(PROJECT_DIRECTORY);
+			self->notifyUpdate();
+			return;
+		}
+		else
+		{
+			rel = std::filesystem::weakly_canonical(modulePath).lexically_relative(std::filesystem::weakly_canonical(rtcDirectory));
+			if(!rel.empty() && *rel.begin() != "..")
+			{
+				baseDirectoryType.select(RTC_DIRECTORY);
+				self->notifyUpdate();
+				return;
+			}
+		}	
+		baseDirectoryType.select(NO_BASE_DIRECTORY);
+		self->notifyUpdate();
+		return;	
+	}	
+}
+
+std::filesystem::path ControllerRTCItemImpl::getModuleFullPath(std::filesystem::path& modulePath)
+{
+	if (!modulePath.is_absolute())
+	{
+		if (baseDirectoryType.is(NO_BASE_DIRECTORY)) {
+			return modulePath;
+		}
+		else if (baseDirectoryType.is(RTC_DIRECTORY)) {
+			return rtcDirectory / modulePath;
+		}
+		else if (baseDirectoryType.is(PROJECT_DIRECTORY)) {
+			std::string projectDir = ProjectManager::instance()->currentProjectDirectory();
+			if(!projectDir.empty())
+			{
+				return std::filesystem::path(projectDir) / modulePath;
+			}
+			else if(!projectDirectoryPath.empty())
+			{
+				return projectDirectoryPath / modulePath;
+			}
+				
+		}
+	}
+	return modulePath;
+}
+
+
 void ControllerRTCItemImpl::setRTCModule(const std::string& name)
 {
+    /*
     if(name != moduleNameProperty){
         std::filesystem::path modulePath(name);
         if(modulePath.is_absolute()){
@@ -207,6 +267,14 @@ void ControllerRTCItemImpl::setRTCModule(const std::string& name)
         moduleNameProperty = modulePath.string();
         self->createRTC();
     }
+    */
+    if (name.empty())
+    {
+        return;
+    }
+    std::filesystem::path path = std::filesystem::path(name);
+    moduleNameProperty = getModuleFullPath(path).string();
+    self->createRTC();
 }
 
 
@@ -297,9 +365,14 @@ std::string ControllerRTCItemImpl::getModuleFilename()
     }
     
     std::filesystem::path path(moduleNameProperty);
+    
+    path = getModuleFullPath(path);
+
+    
 
     moduleName = path.stem().string();
     
+    /*
     if(!path.is_absolute()){
         if(baseDirectoryType.is(RTC_DIRECTORY)){
             path = rtcDirectory / path;
@@ -323,6 +396,7 @@ std::string ControllerRTCItemImpl::getModuleFilename()
         path += ".";
         path += DLL_EXTENSION;
     }
+    */
         
     if(std::filesystem::exists(path)){
         return path.string();
@@ -661,6 +735,8 @@ bool ControllerRTCItem::store(Archive& archive)
 
 bool ControllerRTCItemImpl::store(Archive& archive)
 {
+    std::filesystem::path projectDirectory = archive.projectDirectory();
+    setBaseDirectoryType(projectDirectory);
     archive.writeRelocatablePath("module", moduleNameProperty);
     archive.write("baseDirectory", baseDirectoryType.selectedSymbol(), DOUBLE_QUOTED);
     archive.write("instanceName", rtcInstanceNameProperty, DOUBLE_QUOTED);
@@ -681,6 +757,7 @@ bool ControllerRTCItem::restore(const Archive& archive)
 bool ControllerRTCItemImpl::restore(const Archive& archive)
 {
     DDEBUG("ControllerRTCItemImpl::restore");
+    projectDirectoryPath = archive.projectDirectory();
     string value;
     if(archive.read("module", value) || archive.read("moduleName", value)){
         std::filesystem::path path(archive.expandPathVariables(value));

--- a/src/OpenRTMPlugin/RTCItem.cpp
+++ b/src/OpenRTMPlugin/RTCItem.cpp
@@ -17,6 +17,7 @@
 #include <rtm/RTObject.h>
 #include <cnoid/Format>
 #include "gettext.h"
+#include <rtm/CORBA_RTCUtil.h>
 
 #include "LoggerUtil.h"
 
@@ -34,13 +35,13 @@ class RTComponentImpl
 public:
     RTC::RTObject_var rtcRef;
     RTC::RtcBase* rtc_;
-    cnoid::stdx::filesystem::path modulePath;
+    std::filesystem::path modulePath;
     Process rtcProcess;
     std::string componentName;
     MessageView* mv;
 
-    RTComponentImpl(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& prop);
-    void init(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& properties);
+    RTComponentImpl(const std::filesystem::path& modulePath, PropertyMap& prop);
+    void init(const std::filesystem::path& modulePath, PropertyMap& properties);
     bool createRTC(PropertyMap& properties);
     bool isValid() const;
     void setupModules(string& fileName, string& initFuncName, string& componentName, PropertyMap& properties);
@@ -48,6 +49,7 @@ public:
     void createProcess(string& command, PropertyMap& properties);
     void deleteRTC();
     void activate();
+    void deactivate();
     void onReadyReadServerProcessOutput();
 };
 
@@ -97,14 +99,14 @@ RTCItem::RTCItem()
     baseDirectoryType.select(RTC_DIRECTORY);
     oldBaseDirectoryType = baseDirectoryType.which();
 
-    rtcDirectory = cnoid::stdx::filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
+    rtcDirectory = std::filesystem::path(executableTopDirectory()) / CNOID_PLUGIN_SUBDIR / "rtc";
 
     isActivationEnabled_ = false;
 }
 
 
 RTCItem::RTCItem(const RTCItem& org)
-    : Item(org),
+    : ControllerItem(org),
     os(MessageView::instance()->cout()),
     periodicType(org.periodicType),
     baseDirectoryType(org.baseDirectoryType),
@@ -224,6 +226,22 @@ void RTCItem::setActivationEnabled(bool on)
     }
 }
 
+bool RTCItem::start()
+{
+    if (rtcomp) {
+        rtcomp->activate();
+    }
+    return true;
+}
+
+
+void RTCItem::stop()
+{
+    if (rtcomp) {
+        rtcomp->deactivate();
+    }
+}
+
 void RTCItem::doPutProperties(PutPropertyFunction& putProperty)
 {
     Item::doPutProperties(putProperty);
@@ -255,6 +273,9 @@ bool RTCItem::store(Archive& archive)
     if (!Item::store(archive)) {
         return false;
     }
+    std::filesystem::path projectDirectory = archive.projectDirectory();
+    setbaseDirectoryType(projectDirectory);
+    
     archive.writeRelocatablePath("module", moduleName);
     archive.write("baseDirectory", baseDirectoryType.selectedSymbol(), DOUBLE_QUOTED);
     archive.write("periodicType", periodicType.selectedSymbol());
@@ -268,14 +289,14 @@ bool RTCItem::restore(const Archive& archive)
 {
     DDEBUG("RTCItem::restore");
     
-    projectDirectory = archive.projectDirectory();
+    projectDirectoryPath = archive.projectDirectory();
 
     if (!Item::restore(archive)) {
         return false;
     }
     string value;
     if (archive.read("module", value) || archive.read("moduleName", value)) {
-        cnoid::stdx::filesystem::path path(archive.expandPathVariables(value));
+        std::filesystem::path path(archive.expandPathVariables(value));
         moduleName = path.make_preferred().string();
     }
     if (archive.read("baseDirectory", value) || archive.read("RelativePathBase", value)) {
@@ -299,26 +320,60 @@ bool RTCItem::restore(const Archive& archive)
 }
 
 
+void RTCItem::setbaseDirectoryType(std::filesystem::path& projectDirectory)
+{
+		if (modulePath.is_absolute()) {
+			auto rel = std::filesystem::weakly_canonical(modulePath).lexically_relative(std::filesystem::weakly_canonical(projectDirectory));
+			if(!rel.empty() && *rel.begin() != "..")
+			{
+				baseDirectoryType.select(PROJECT_DIRECTORY);
+				notifyUpdate();
+				return;
+			}
+			else
+			{
+				rel = std::filesystem::weakly_canonical(modulePath).lexically_relative(std::filesystem::weakly_canonical(rtcDirectory));
+				if(!rel.empty() && *rel.begin() != "..")
+				{
+					baseDirectoryType.select(RTC_DIRECTORY);
+					notifyUpdate();
+					return;
+				}
+
+			}
+			
+			baseDirectoryType.select(NO_BASE_DIRECTORY);
+			notifyUpdate();
+			return;
+			
+		}
+}
+
 bool RTCItem::convertAbsolutePath()
 {
     modulePath = moduleName;
+    if (moduleName.empty())
+    {
+        return false;
+    }
     if (!modulePath.is_absolute()) {
         if (baseDirectoryType.is(RTC_DIRECTORY)) {
             modulePath = rtcDirectory / modulePath;
         } else if (baseDirectoryType.is(PROJECT_DIRECTORY)) {
+			
             string projectDir = ProjectManager::instance()->currentProjectDirectory();
             if (projectDir.empty()) {
-                if(projectDirectory.empty())
+                if(projectDirectoryPath.empty())
                 {
                     mv->putln(_("Please save the project."));
                     return false;
                 }
                 else
                 {
-                    modulePath = cnoid::stdx::filesystem::path(projectDirectory) / modulePath;
+                    modulePath = std::filesystem::path(projectDirectoryPath) / modulePath;
                 }
             } else {
-                modulePath = cnoid::stdx::filesystem::path(projectDir) / modulePath;
+                modulePath = std::filesystem::path(projectDir) / modulePath;
             }
         }
     }
@@ -326,14 +381,14 @@ bool RTCItem::convertAbsolutePath()
 }
 
 
-RTComponent::RTComponent(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& prop)
+RTComponent::RTComponent(const std::filesystem::path& modulePath, PropertyMap& prop)
 {
     DDEBUG("RTComponent::RTComponent");
     impl = new RTComponentImpl(modulePath, prop);
 }
 
 
-RTComponentImpl::RTComponentImpl(const cnoid::stdx::filesystem::path& modulePath, PropertyMap& prop)
+RTComponentImpl::RTComponentImpl(const std::filesystem::path& modulePath, PropertyMap& prop)
 {
     rtc_ = nullptr;
     rtcRef = RTC::RTObject::_nil();
@@ -350,7 +405,7 @@ RTComponent::~RTComponent()
 }
 
 
-void RTComponentImpl::init(const cnoid::stdx::filesystem::path& modulePath_, PropertyMap& prop)
+void RTComponentImpl::init(const std::filesystem::path& modulePath_, PropertyMap& prop)
 {
     DDEBUG("RTComponentImpl::init");
     mv = MessageView::instance();
@@ -373,7 +428,7 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
 
     string actualFilename;
 
-    if (cnoid::stdx::filesystem::exists(modulePath)) {
+    if (std::filesystem::exists(modulePath)) {
         actualFilename = getNativePathString(modulePath);
         if (modulePath.extension() == DLL_SUFFIX) {
             string initFunc(componentName + "Init");
@@ -382,13 +437,13 @@ bool RTComponentImpl::createRTC(PropertyMap& prop)
             createProcess(actualFilename, prop);
         }
     } else {
-        cnoid::stdx::filesystem::path exePath(modulePath.string() + EXEC_SUFFIX);
-        if (cnoid::stdx::filesystem::exists(exePath)) {
+        std::filesystem::path exePath(modulePath.string() + EXEC_SUFFIX);
+        if (std::filesystem::exists(exePath)) {
             actualFilename = getNativePathString(exePath);
             createProcess(actualFilename, prop);
         } else {
-            cnoid::stdx::filesystem::path dllPath(modulePath.string() + DLL_SUFFIX);
-            if (cnoid::stdx::filesystem::exists(dllPath)) {
+            std::filesystem::path dllPath(modulePath.string() + DLL_SUFFIX);
+            if (std::filesystem::exists(dllPath)) {
                 actualFilename = getNativePathString(dllPath);
                 string initFunc(componentName + "Init");
                 setupModules(actualFilename, initFunc, componentName, prop);
@@ -551,12 +606,43 @@ void RTComponent::activate()
 void RTComponentImpl::activate()
 {
     if (rtc_) {
+        /*
         RTC::ExecutionContextList_var eclist = rtc_->get_owned_contexts();
         for (CORBA::ULong i = 0; i < eclist->length(); ++i) {
             if (!CORBA::is_nil(eclist[i])) {
                 eclist[i]->activate_component(rtc_->getObjRef());
                 break;
             }
+        }
+        */
+        
+        if (CORBA_RTCUtil::is_in_error(rtc_->getObjRef()))
+        {
+            CORBA_RTCUtil::reset(rtc_->getObjRef());
+        }
+        if (CORBA_RTCUtil::is_in_inactive(rtc_->getObjRef()))
+        {
+            CORBA_RTCUtil::activate(rtc_->getObjRef());
+        }
+    }
+}
+
+void RTComponent::deactivate()
+{
+    impl->deactivate();
+}
+
+
+void RTComponentImpl::deactivate()
+{
+    if (rtc_) {
+        if (CORBA_RTCUtil::is_in_error(rtc_->getObjRef()))
+        {
+            CORBA_RTCUtil::reset(rtc_->getObjRef());
+        }
+        if (CORBA_RTCUtil::is_in_active(rtc_->getObjRef()))
+        {
+            CORBA_RTCUtil::deactivate(rtc_->getObjRef());
         }
     }
 }

--- a/src/OpenRTMPlugin/RTCItem.cpp
+++ b/src/OpenRTMPlugin/RTCItem.cpp
@@ -94,6 +94,7 @@ RTCItem::RTCItem()
     ss << periodicRate;
     properties.insert(make_pair(string("exec_cxt.periodic.rate"), ss.str()));
 
+    baseDirectoryType.setSymbol(NO_BASE_DIRECTORY, N_("None"));
     baseDirectoryType.setSymbol(RTC_DIRECTORY, N_("RTC directory"));
     baseDirectoryType.setSymbol(PROJECT_DIRECTORY, N_("Project directory"));
     baseDirectoryType.select(RTC_DIRECTORY);

--- a/src/OpenRTMPlugin/RTCItem.h
+++ b/src/OpenRTMPlugin/RTCItem.h
@@ -1,7 +1,7 @@
 #ifndef CNOID_OPENRTM_PLUGIN_RTC_ITEM_H
 #define CNOID_OPENRTM_PLUGIN_RTC_ITEM_H
 
-#include <cnoid/Item>
+#include <cnoid/ControllerItem>
 #include <cnoid/Selection>
 #include <cnoid/stdx/filesystem>
 #include <map>
@@ -24,20 +24,21 @@ class RTComponentImpl;
 class RTComponent
 {
 public:
-    RTComponent(const stdx::filesystem::path& modulePath, PropertyMap& properties);
+    RTComponent(const std::filesystem::path& modulePath, PropertyMap& properties);
     ~RTComponent();
     void deleteRTC();
     RTC::RtcBase* rtc();
     bool isValid() const;
     const std::string& name() const;
     void activate();
+    void deactivate();
     const bool runningProcess() const;
 
 private:
     RTComponentImpl* impl;
 };
 
-class CNOID_EXPORT RTCItem : public Item
+class CNOID_EXPORT RTCItem : public ControllerItem
 {
 public:
     static void initialize(ExtensionManager* ext);
@@ -69,6 +70,8 @@ public:
     void setBaseDirectoryType(int base);
     void setActivationEnabled(bool on);
     bool isActivationEnabled() const { return isActivationEnabled_; }
+    virtual bool start() override;
+    virtual void stop() override;
 
 protected:
     virtual void onConnectedToRoot() override;
@@ -89,14 +92,15 @@ private:
     PropertyMap properties;
     Selection baseDirectoryType;
     int oldBaseDirectoryType;
-    stdx::filesystem::path rtcDirectory;
-    stdx::filesystem::path modulePath;
-    stdx::filesystem::path projectDirectory;
+    std::filesystem::path rtcDirectory;
+    std::filesystem::path modulePath;
+    std::filesystem::path projectDirectoryPath;
     bool isActivationEnabled_;
 
     void deleteRTCInstance();
     void updateRTCInstance(bool forceUpdate = true);
     bool convertAbsolutePath();
+    void setbaseDirectoryType(std::filesystem::path& projectDirectory);
 };
 
 typedef ref_ptr<RTCItem> RTCItemPtr;


### PR DESCRIPTION
以下の修正をした。

- ControllerRTCItem、RTCItemについて、プロジェクト保存時に、ベースディレクトリの項目を自動的に設定するように修正した。
  - プロジェクトファイル(.cnoid)のディレクトリにRTCモジュールを格納している場合に、PROJECT_DIRECTORYに設定
  - プラグインのサブディレクトリにRTCモジュールを格納している場合、RTC_DIRECTORYに設定
  - それ以外はNO_BASE_DIRECTORYに設定
- RTCItemで起動したRTCがシミュレーション開始時にアクティブ化、終了時に非アクティブ化するように変更